### PR TITLE
feat(site): v2 UI polish, Reset years, richer cards, Wikipedia block

### DIFF
--- a/site/src/data/bibliography.csv
+++ b/site/src/data/bibliography.csv
@@ -1,5 +1,15 @@
-Year,Title,Type,Co-authors/Editors,Publication,ISBN
-2006,Fredric Jameson: Live Theory,Book,,Continuum,9780826461430
-2015,Assemblage and the Everyday,Article,,Deleuze Studies,
-2017,Assemblage, Affect, and Art,Article,,Deleuze Studies,
-2021,Assemblage Theory and Method,Book,,Bloomsbury,9781350010000
+Year,Title,Type,Co-authors/Editors,Publication,ISBN,PublisherURL,GoogleBooksURL,PhilPapersURL
+1997,Deleuze and Literature,Edited volume,Claire Colebrook,Edinburgh University Press,9780748612725,,,
+2000,Michel de Certeau,Book,,SAGE Publications,9780761968967,,,
+2000,A Dictionary of Critical Theory,Book,,Oxford University Press,9780195126691,,,
+2000,Deleuzism: A Metacommentary,Book,,Duke University Press,9780822321813,,,
+2004,Deleuze and the Schizoanalysis of Cinema,Edited volume,Patricia Pisters; Adrian Parr,Continuum,9780826479437,,,
+2006,Fredric Jameson: Live Theory,Book,,Continuum,9780826461430,https://www.bloomsbury.com/us/fredric-jameson-9780826461430,,https://philpapers.org/rec/BUCFJL
+2008,Deleuze and Guattari's 'Anti-Oedipus': A Critical Introduction and Guide,Book,,Routledge,9781847064108,,,
+2011,Deleuze and the Schizoanalysis of Cinema,Edited volume,Patricia Pisters,Bloomsbury,9781441173824,,,
+2013,Deleuze and the Schizoanalysis of Visual Culture,Edited volume,Laura Cull,Bloomsbury,9781780936708,,,
+2015,Assemblage and the Everyday,Article,,Deleuze Studies,,,,
+2017,Assemblage, Affect, and Art,Article,,Deleuze Studies,,,,
+2017,The Incomplete Project of Schizoanalysis,Book,,Edinburgh University Press,9780748676122,,,
+2019,On Jameson,Book,,Haymarket Books,9781608469080,,,
+2021,Assemblage Theory and Method,Book,,Bloomsbury,978-1350014680,https://www.bloomsbury.com/9781350014680,https://books.google.com/books?vid=ISBN9781350014680,https://philpapers.org/rec/BUCAAT

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -4,6 +4,28 @@ body {
   padding: 1rem;
   background: #f5f5f5;
   color: #333;
+  --muted: #666;
+}
+
+.header h1 { font-size: 1.6rem; }
+.card h3 { font-size: 1.05rem; }
+.container { max-width: 1200px; margin: 0 auto; }
+
+.badge {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.75rem;
+  background: #eee;
+  text-decoration: none;
+}
+
+.button {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #ccc;
+  background: #fff;
+  border-radius: 4px;
+  cursor: pointer;
 }
 
 .controls {
@@ -65,5 +87,5 @@ body {
 }
 
 .notes {
-  margin-top: 2rem;
+  margin-top: 0;
 }

--- a/site/src/lib/csv.js
+++ b/site/src/lib/csv.js
@@ -18,5 +18,9 @@ export async function loadBibliography() {
         : [],
       venue: r.Publication,
       isbn: r.ISBN,
+      PublisherURL: r.PublisherURL,
+      GoogleBooksURL: r.GoogleBooksURL,
+      PhilPapersURL: r.PhilPapersURL,
+      doi: r.DOI,
     }))
 }

--- a/site/src/lib/wiki.js
+++ b/site/src/lib/wiki.js
@@ -1,0 +1,21 @@
+// Generates Wikipedia-ready wikitext from normalized entries.
+export function generateWiki(entries) {
+  const authored = entries.filter(e => e.type === 'Book').sort((a,b)=>a.title.localeCompare(b.title))
+  const edited   = entries.filter(e => e.type === 'Edited volume').sort((a,b)=>a.title.localeCompare(b.title))
+  const articles = entries.filter(e => e.type === 'Article').sort((a,b)=>a.title.localeCompare(b.title))
+
+  const fmtBook = b =>
+    `* ''${b.title}''.${b.venue ? ` ${b.venue}.` : ''}${b.year ? ` ${b.year}.` : ''}${b.isbn ? ` ISBN ${b.isbn}.` : ''}`
+
+  const fmtEd = e =>
+    `* ${e.collaborators.join('; ')} (eds.). ''${e.title}''.${e.venue ? ` ${e.venue}.` : ''}${e.year ? ` ${e.year}.` : ''}`
+
+  const fmtArt = a =>
+    `* "${a.title}."${a.venue ? ` ''${a.venue}''` : ''}${a.year ? ` (${a.year})` : ''}${a.doi ? `. doi:${a.doi}` : ''}`
+
+  const blocks = []
+  if (authored.length) blocks.push('===Authored books===\n' + authored.map(fmtBook).join('\n'))
+  if (edited.length)   blocks.push('===Edited books===\n'  + edited.map(fmtEd).join('\n'))
+  if (articles.length) blocks.push('===Selected articles===\n' + articles.map(fmtArt).join('\n'))
+  return blocks.join('\n\n')
+}


### PR DESCRIPTION
## Summary
- load full bibliography dataset and expose optional link columns
- add year range reset, denser cards, and inline link badges
- generate Wikipedia-ready wikitext for filtered entries with copy-to-clipboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68afebdf9c94832b861c1d375e53da05