### PR TITLE
docs: scaffold instruction tracks

### DIFF
--- a/instructions/README.md
+++ b/instructions/README.md
@@ -1,0 +1,13 @@
+# Ian Buchanan Vault — Instruction Tracks
+
+This folder contains modular instruction tracks for the project.  
+Each page provides goals, deliverables, inputs, and stretch ideas.  
+
+**Tracks:**
+- [Core Instructions](./core_instructions.md)
+- [Teaching Pack](./teaching_pack.md)
+- [Tagging Playbook](./tagging_playbook.md)
+- [Comparative Scholars Track](./comparative_track.md)
+- [Publication Pipeline & Style](./publication_pipeline.md)
+
+Use these tracks as building blocks: choose one, expand, refine, and implement.

--- a/instructions/comparative_track.md
+++ b/instructions/comparative_track.md
@@ -1,0 +1,16 @@
+# Comparative Scholars Track (Track D)
+
+## Goal
+Provide instructions for adding parallel datasets (e.g., Massumi, Colebrook, Braidotti).
+
+## Deliverables
+- Data schema alignment guide (so multiple scholars fit same model).
+- Curation rules (handling translations, editions, duplicates).
+- Guidelines for “Selected works” across different scholars.
+
+## Inputs Needed
+- First two comparison scholars to target.
+
+## Stretch Ideas
+- Comparative visualizations (Buchanan vs peers).
+- Cross-tagging shared concepts.

--- a/instructions/core_instructions.md
+++ b/instructions/core_instructions.md
@@ -1,0 +1,17 @@
+# Core Instructions (Track A)
+
+## Goal
+Revise and tighten the Vault’s master brief. Explicitly prioritize website outputs and pedagogy.
+
+## Deliverables
+- Updated master brief (purpose, scope, outputs, tone).
+- Clearer Phase 2 web goals: timeline, tags, maps, reader mode.
+- Contribution guidelines (PR etiquette, file naming, data hygiene).
+
+## Inputs Needed
+- Current instructions draft.
+- Site features list.
+
+## Stretch Ideas
+- Add “living roadmap” section with milestones.
+- Include philosophy on style (diagrammatic + rigorous).

--- a/instructions/publication_pipeline.md
+++ b/instructions/publication_pipeline.md
@@ -1,0 +1,18 @@
+# Publication Pipeline & Style (Track E)
+
+## Goal
+Make the Vault publish reproducible outputs in standardized style.
+
+## Deliverables
+- Auto-generate:
+  - Wikipedia “Selected works” block from CSV
+  - Syllabus snippets (Markdown)
+  - One-page scholar profile (bio + key works)
+- Editorial style sheet (dates, ISBN-13, italics, citations).
+
+## Inputs Needed
+- Citation style preference (Chicago short, MLA, etc.).
+
+## Stretch Ideas
+- Export to multiple formats (PDF, HTML).
+- Connect to Zotero or Google Scholar for live updates.

--- a/instructions/tagging_playbook.md
+++ b/instructions/tagging_playbook.md
@@ -1,0 +1,16 @@
+# Tagging Playbook (Track C)
+
+## Goal
+Standardize tagging so content is filterable and comparable.
+
+## Deliverables
+- Controlled vocabulary: e.g. assemblage, schizoanalysis, affect, war machine, deterritorialization.
+- Rules for assigning tags (primary/secondary, disambiguation).
+- CSV column spec and QA checklist.
+
+## Inputs Needed
+- Preferred tag list from team (or seed list proposed here).
+
+## Stretch Ideas
+- Link tags to concept maps on the website.
+- Auto-suggest tags based on text scan.

--- a/instructions/teaching_pack.md
+++ b/instructions/teaching_pack.md
@@ -1,0 +1,16 @@
+# Teaching Pack (Track B)
+
+## Goal
+Add a teaching layer to the Vault.
+
+## Deliverables
+- Templates for lecture slides, seminar prompts, and reading guides keyed to Buchanan’s works.
+- Rubric for student exercises (assemblage mapping, schizoanalytic case studies).
+
+## Inputs Needed
+- Target course level (undergrad, postgrad).
+- Preferred teaching formats.
+
+## Stretch Ideas
+- Interactive quiz or flashcards.
+- “Teaching notes” sidecar to each major text.


### PR DESCRIPTION
## Summary
- Add README describing instruction track modules
- Provide skeleton pages for core, teaching, tagging, comparative, and publication tracks

## Testing
- `npm test` *(fails: Missing script "test")*
- `git push` *(fails: No configured push destination)*

------
https://chatgpt.com/codex/tasks/task_e_68aff644a704832b8ed8ed1bb056e8af