### PR TITLE
feat(site): add controlled vocab tagging and tag filter UI

### DIFF
--- a/site/src/App.jsx
+++ b/site/src/App.jsx
@@ -6,6 +6,7 @@ import { createSearch } from './lib/search.js'
 import { groupByYear, yearsRange } from './lib/group.js'
 import { typeColors as TYPE_COLORS } from './lib/colors.js'
 import { generateWiki } from './lib/wiki.js'
+import { TAGS } from './lib/tags.js'
 
 function App() {
   const [entries, setEntries] = useState([])
@@ -14,6 +15,7 @@ function App() {
   const [bounds, setBounds] = useState([0, 0])
   const [yearRange, setYearRange] = useState([0, 0])
   const [searchTerm, setSearchTerm] = useState('')
+  const [activeTags, setActiveTags] = useState([])
 
   useEffect(() => {
     loadBibliography().then((data) => {
@@ -31,7 +33,8 @@ function App() {
     return entries
       .filter((e) => typeFilter === 'All' || e.type === typeFilter)
       .filter((e) => e.year >= yearRange[0] && e.year <= yearRange[1])
-  }, [entries, typeFilter, yearRange])
+      .filter((e) => activeTags.every((t) => e.tags.includes(t)))
+  }, [entries, typeFilter, yearRange, activeTags])
 
   const results = useMemo(() => {
     if (!searchTerm) return filtered
@@ -125,6 +128,19 @@ function App() {
                 <div style={{marginTop:4,fontSize:'.9rem'}}>With: {item.collaborators.join(', ')}</div>
               )}
               {item.isbn && <div style={{marginTop:4,fontSize:'.9rem',wordBreak:'break-word'}}>ISBN: {item.isbn}</div>}
+              {item.tags.length > 0 && (
+                <div style={{marginTop:8, display:'flex', gap:6, flexWrap:'wrap'}}>
+                  {item.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="badge"
+                      style={{ background: '#232734', color: 'var(--muted)' }}
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              )}
               <div style={{marginTop:8, display:'flex', gap:8, flexWrap:'wrap'}}>
                 {item.PublisherURL && <a className="badge" href={item.PublisherURL} target="_blank" rel="noreferrer">Publisher</a>}
                 {item.GoogleBooksURL && <a className="badge" href={item.GoogleBooksURL} target="_blank" rel="noreferrer">Google Books</a>}
@@ -134,6 +150,29 @@ function App() {
           ))}
         </div>
         <div style={{width:'300px',flexShrink:0,display:'flex',flexDirection:'column',gap:'1rem'}}>
+          <div className="card">
+            <strong>Tags</strong>
+            <div style={{marginTop:6, display:'flex', flexWrap:'wrap', gap:6}}>
+              {TAGS.map((tag) => (
+                <button
+                  key={tag}
+                  className="badge"
+                  style={{
+                    cursor: 'pointer',
+                    background: activeTags.includes(tag) ? 'var(--accent)' : '#232734',
+                    color: activeTags.includes(tag) ? '#08121e' : 'var(--muted)',
+                  }}
+                  onClick={() =>
+                    setActiveTags((t) =>
+                      t.includes(tag) ? t.filter((x) => x !== tag) : [...t, tag],
+                    )
+                  }
+                >
+                  {tag}
+                </button>
+              ))}
+            </div>
+          </div>
           <div className="card">
             <strong>Wikipedia Block</strong>
             <textarea

--- a/site/src/data/bibliography.csv
+++ b/site/src/data/bibliography.csv
@@ -1,15 +1,15 @@
-Year,Title,Type,Co-authors/Editors,Publication,ISBN,PublisherURL,GoogleBooksURL,PhilPapersURL
-1997,Deleuze and Literature,Edited volume,Claire Colebrook,Edinburgh University Press,9780748612725,,,
-2000,Michel de Certeau,Book,,SAGE Publications,9780761968967,,,
-2000,A Dictionary of Critical Theory,Book,,Oxford University Press,9780195126691,,,
-2000,Deleuzism: A Metacommentary,Book,,Duke University Press,9780822321813,,,
-2004,Deleuze and the Schizoanalysis of Cinema,Edited volume,Patricia Pisters; Adrian Parr,Continuum,9780826479437,,,
-2006,Fredric Jameson: Live Theory,Book,,Continuum,9780826461430,https://www.bloomsbury.com/us/fredric-jameson-9780826461430,,https://philpapers.org/rec/BUCFJL
-2008,Deleuze and Guattari's 'Anti-Oedipus': A Critical Introduction and Guide,Book,,Routledge,9781847064108,,,
-2011,Deleuze and the Schizoanalysis of Cinema,Edited volume,Patricia Pisters,Bloomsbury,9781441173824,,,
-2013,Deleuze and the Schizoanalysis of Visual Culture,Edited volume,Laura Cull,Bloomsbury,9781780936708,,,
-2015,Assemblage and the Everyday,Article,,Deleuze Studies,,,,
-2017,Assemblage, Affect, and Art,Article,,Deleuze Studies,,,,
-2017,The Incomplete Project of Schizoanalysis,Book,,Edinburgh University Press,9780748676122,,,
-2019,On Jameson,Book,,Haymarket Books,9781608469080,,,
-2021,Assemblage Theory and Method,Book,,Bloomsbury,978-1350014680,https://www.bloomsbury.com/9781350014680,https://books.google.com/books?vid=ISBN9781350014680,https://philpapers.org/rec/BUCAAT
+Year,Title,Type,Co-authors/Editors,Publication,ISBN,PublisherURL,GoogleBooksURL,PhilPapersURL,Tags
+1997,Deleuze and Literature,Edited volume,Claire Colebrook,Edinburgh University Press,9780748612725,,,,Affect
+2000,Michel de Certeau,Book,,SAGE Publications,9780761968967,,,,Politics
+2000,A Dictionary of Critical Theory,Book,,Oxford University Press,9780195126691,,,,Pedagogy
+2000,Deleuzism: A Metacommentary,Book,,Duke University Press,9780822321813,,,,Schizoanalysis;Assemblage
+2004,Deleuze and the Schizoanalysis of Cinema,Edited volume,Patricia Pisters; Adrian Parr,Continuum,9780826479437,,,,Schizoanalysis;Affect
+2006,Fredric Jameson: Live Theory,Book,,Continuum,9780826461430,https://www.bloomsbury.com/us/fredric-jameson-9780826461430,,https://philpapers.org/rec/BUCFJL,Politics;Marxism/Jameson;Pedagogy
+2008,"Deleuze and Guattari's ""Anti-Oedipus"": A Critical Introduction and Guide",Book,,Routledge,9781847064108,,,,Schizoanalysis;Pedagogy
+2011,Deleuze and the Schizoanalysis of Cinema,Edited volume,Patricia Pisters,Bloomsbury,9781441173824,,,,Schizoanalysis;Affect
+2013,Deleuze and the Schizoanalysis of Visual Culture,Edited volume,Laura Cull,Bloomsbury,9781780936708,,,,Schizoanalysis;Affect
+2015,Assemblage and the Everyday,Article,,Deleuze Studies,,,,,Assemblage
+2017,"Assemblage, Affect, and Art",Article,,Deleuze Studies,,,,,Assemblage;Affect
+2017,The Incomplete Project of Schizoanalysis,Book,,Edinburgh University Press,9780748676122,,,,Schizoanalysis
+2019,On Jameson,Book,,Haymarket Books,9781608469080,,,,Marxism/Jameson
+2021,Assemblage Theory and Method,Book,,Bloomsbury,978-1350014680,https://www.bloomsbury.com/9781350014680,https://books.google.com/books?vid=ISBN9781350014680,https://philpapers.org/rec/BUCAAT,Assemblage;Pedagogy

--- a/site/src/lib/csv.js
+++ b/site/src/lib/csv.js
@@ -22,5 +22,8 @@ export async function loadBibliography() {
       GoogleBooksURL: r.GoogleBooksURL,
       PhilPapersURL: r.PhilPapersURL,
       doi: r.DOI,
+      tags: r.Tags
+        ? r.Tags.split(';').map((s) => s.trim()).filter(Boolean)
+        : [],
     }))
 }

--- a/site/src/lib/tags.js
+++ b/site/src/lib/tags.js
@@ -1,0 +1,8 @@
+export const TAGS = [
+  "Assemblage",
+  "Schizoanalysis",
+  "Affect",
+  "Politics",
+  "Pedagogy",
+  "Marxism/Jameson"
+]


### PR DESCRIPTION
## Summary
- add controlled vocabulary tags and tags.js helper
- extend CSV schema and loader to parse tags
- filter and display items by selected tags in the UI

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aff7495c58832b99c7773944401f11