### PR TITLE
feat(site): add force-directed Concept Map visualization for tags↔works

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -14,7 +14,8 @@
     "react-dom": "^19.1.1",
     "papaparse": "^5.5.3",
     "marked": "^16.2.1",
-    "fuse.js": "^7.1.0"
+    "fuse.js": "^7.1.0",
+    "react-force-graph": "^1.55.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/site/src/App.jsx
+++ b/site/src/App.jsx
@@ -7,6 +7,7 @@ import { groupByYear, yearsRange } from './lib/group.js'
 import { typeColors as TYPE_COLORS } from './lib/colors.js'
 import { generateWiki } from './lib/wiki.js'
 import { TAGS } from './lib/tags.js'
+import ConceptMap from './components/ConceptMap.jsx'
 
 function App() {
   const [entries, setEntries] = useState([])
@@ -150,6 +151,10 @@ function App() {
           ))}
         </div>
         <div style={{width:'300px',flexShrink:0,display:'flex',flexDirection:'column',gap:'1rem'}}>
+          <div className="card">
+            <strong>Concept Map</strong>
+            <ConceptMap data={filtered} />
+          </div>
           <div className="card">
             <strong>Tags</strong>
             <div style={{marginTop:6, display:'flex', flexWrap:'wrap', gap:6}}>

--- a/site/src/components/ConceptMap.jsx
+++ b/site/src/components/ConceptMap.jsx
@@ -1,0 +1,53 @@
+import React, { useMemo } from 'react'
+import ForceGraph2D from 'react-force-graph-2d'
+
+export default function ConceptMap({ data }) {
+  const graphData = useMemo(() => {
+    const nodes = []
+    const links = []
+    // tag nodes
+    const tagSet = new Set()
+    data.forEach(work => {
+      work.tags.forEach(tag => tagSet.add(tag))
+    })
+    for (const tag of tagSet) {
+      nodes.push({ id: `tag-${tag}`, name: tag, type: 'tag' })
+    }
+
+    // work nodes + links
+    data.forEach(work => {
+      const nodeId = `work-${work.id}`
+      nodes.push({ id: nodeId, name: work.title, type: work.type, year: work.year })
+      work.tags.forEach(tag => {
+        links.push({ source: nodeId, target: `tag-${tag}` })
+      })
+    })
+
+    return { nodes, links }
+  }, [data])
+
+  return (
+    <div style={{ height: '600px', background:'#0f1115', borderRadius:'8px' }}>
+      <ForceGraph2D
+        graphData={graphData}
+        nodeAutoColorBy="type"
+        nodeCanvasObject={(node, ctx, globalScale) => {
+          const label = node.name
+          const fontSize = 12 / globalScale
+          ctx.font = `${fontSize}px Sans-Serif`
+          ctx.fillStyle = node.type === 'tag' ? '#ccc' :
+            node.type === 'Book' ? '#4C9AFF' :
+            node.type === 'Edited volume' ? '#FFB020' :
+            node.type === 'Article' ? '#34C759' : '#aaa'
+          ctx.beginPath()
+          ctx.arc(node.x, node.y, 6, 0, 2 * Math.PI, false)
+          ctx.fill()
+          ctx.fillStyle = 'white'
+          ctx.fillText(label, node.x + 8, node.y + 4)
+        }}
+        linkColor={() => '#555'}
+      />
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- visualize works and tags with a new ConceptMap component using `react-force-graph`
- integrate ConceptMap into the bibliography sidebar and color nodes by type
- add `react-force-graph` dependency

## Testing
- `yarn lint` *(fails: site@workspace:.: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68affa7f0e68832b91454fa6ff50a583