### PR TITLE
style(site): compact per-card citation UI (★ badge, link pill, spacing)

### DIFF
--- a/site/src/App.jsx
+++ b/site/src/App.jsx
@@ -198,14 +198,24 @@ function App() {
                 </span>
               </div>
               <div style={{color:'var(--muted)'}}>{item.year} — {item.venue}</div>
-              <div style={{marginTop:6, display:'flex', gap:8, alignItems:'center', flexWrap:'wrap'}}>
-                <span className="badge" title="Google Scholar citations">★ {item.citations || 0}</span>
-                {item.ScholarURL && <a className="badge" href={item.ScholarURL} target="_blank" rel="noreferrer">Scholar</a>}
+              <div className="meta-row">
+                <span className="cite-badge" title={`Citations: ${item.citations || 0}`}>★ {item.citations || 0}</span>
+                {item.ScholarURL && (
+                  <a className="link-pill" href={item.ScholarURL} target="_blank" rel="noreferrer">
+                    Scholar
+                  </a>
+                )}
               </div>
               {item.collaborators.length > 0 && (
-                <div style={{marginTop:4,fontSize:'.9rem'}}>With: {item.collaborators.join(', ')}</div>
+                <div className="small-muted" style={{marginTop:4}}>
+                  With: {item.collaborators.join(', ')}
+                </div>
               )}
-              {item.isbn && <div style={{marginTop:4,fontSize:'.9rem',wordBreak:'break-word'}}>ISBN: {item.isbn}</div>}
+              {item.isbn && (
+                <div className="small-muted" style={{marginTop:4, wordBreak:'break-word'}}>
+                  ISBN: {item.isbn}
+                </div>
+              )}
               {item.tags.length > 0 && (
                 <div style={{marginTop:8, display:'flex', gap:6, flexWrap:'wrap'}}>
                   {item.tags.map((tag) => (

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -81,3 +81,10 @@ body {
   height:8px;
   border-radius:2px;
 }
+
+/* Citation badge + link pills */
+.meta-row { display:flex; gap:8px; align-items:center; flex-wrap:wrap; margin-top:6px; }
+.cite-badge { font-size:.78rem; padding:.12rem .45rem; border-radius:999px; background:#232734; color:var(--muted); }
+.link-pill { font-size:.78rem; padding:.12rem .45rem; border-radius:999px; background:#1b2030; color:#aeb4c0; text-decoration:none; border:1px solid #2a3140; }
+.link-pill:hover { filter:brightness(1.12); }
+.small-muted { font-size:.9rem; color:var(--muted); }


### PR DESCRIPTION
## Summary
- add utility classes for citation badge, link pill and muted metadata
- simplify per-card citation section with ★ count and optional Scholar pill
- use compact muted text for collaborators and ISBN blocks

## Testing
- `cd site && yarn lint && echo 'lint success'`


------
https://chatgpt.com/codex/tasks/task_e_68b0179a9938832b95ade85fe7891028