### PR TITLE
feat(audit): coverage dashboard and metadata audit page

### DIFF
--- a/site/src/App.jsx
+++ b/site/src/App.jsx
@@ -72,8 +72,9 @@ function App() {
 
   return (
     <div className="app container">
-      <div className="header">
+      <div className="header" style={{display:'flex',justifyContent:'space-between',alignItems:'center'}}>
         <h1>Bibliography</h1>
+        <a className="button" href="/audit">Audit</a>
       </div>
       <div className="controls">
         <input

--- a/site/src/data/bibliography.csv
+++ b/site/src/data/bibliography.csv
@@ -1,15 +1,15 @@
-Year,Title,Type,Co-authors/Editors,Publication,ISBN,PublisherURL,GoogleBooksURL,PhilPapersURL,Tags,Citations,ScholarURL
-1997,Deleuze and Literature,Edited volume,Claire Colebrook,Edinburgh University Press,9780748612725,,,,Affect,0,
-2000,Michel de Certeau,Book,,SAGE Publications,9780761968967,,,,Politics,0,
-2000,A Dictionary of Critical Theory,Book,,Oxford University Press,9780195126691,,,,Pedagogy,250,https://scholar.google.com/scholar?q=A+Dictionary+of+Critical+Theory
-2000,Deleuzism: A Metacommentary,Book,,Duke University Press,9780822321813,,,,Schizoanalysis;Assemblage,150,https://scholar.google.com/scholar?q=Deleuzism%3A+A+Metacommentary
-2004,Deleuze and the Schizoanalysis of Cinema,Edited volume,Patricia Pisters; Adrian Parr,Continuum,9780826479437,,,,Schizoanalysis;Affect,85,https://scholar.google.com/scholar?q=Deleuze+and+the+Schizoanalysis+of+Cinema
-2006,Fredric Jameson: Live Theory,Book,,Continuum,9780826461430,https://www.bloomsbury.com/us/fredric-jameson-9780826461430,,https://philpapers.org/rec/BUCFJL,Politics;Marxism/Jameson;Pedagogy,210,https://scholar.google.com/scholar?q=Fredric+Jameson%3A+Live+Theory
-2008,"Deleuze and Guattari's ""Anti-Oedipus"": A Critical Introduction and Guide",Book,,Routledge,9781847064108,,,,Schizoanalysis;Pedagogy,300,https://scholar.google.com/scholar?q=Deleuze+and+Guattari%27s+Anti-Oedipus
-2011,Deleuze and the Schizoanalysis of Cinema,Edited volume,Patricia Pisters,Bloomsbury,9781441173824,,,,Schizoanalysis;Affect,70,https://scholar.google.com/scholar?q=Deleuze+and+the+Schizoanalysis+of+Cinema
-2013,Deleuze and the Schizoanalysis of Visual Culture,Edited volume,Laura Cull,Bloomsbury,9781780936708,,,,Schizoanalysis;Affect,40,https://scholar.google.com/scholar?q=Deleuze+and+the+Schizoanalysis+of+Visual+Culture
-2015,Assemblage and the Everyday,Article,,Deleuze Studies,,,,,Assemblage,145,https://scholar.google.com/scholar?q=Assemblage+and+the+Everyday
-2017,"Assemblage, Affect, and Art",Article,,Deleuze Studies,,,,,Assemblage;Affect,120,https://scholar.google.com/scholar?q=Assemblage,+Affect,+and+Art
-2017,The Incomplete Project of Schizoanalysis,Book,,Edinburgh University Press,9780748676122,,,,Schizoanalysis,60,https://scholar.google.com/scholar?q=The+Incomplete+Project+of+Schizoanalysis
-2019,On Jameson,Book,,Haymarket Books,9781608469080,,,,Marxism/Jameson,30,https://scholar.google.com/scholar?q=On+Jameson+Buchanan
-2021,Assemblage Theory and Method,Book,,Bloomsbury,978-1350014680,https://www.bloomsbury.com/9781350014680,https://books.google.com/books?vid=ISBN9781350014680,https://philpapers.org/rec/BUCAAT,Assemblage;Pedagogy,320,https://scholar.google.com/scholar?q=Assemblage+Theory+and+Method
+Year,Title,Type,Co-authors/Editors,Publication,ISBN,Tags,DOI,URL_Publisher,URL_GoogleBooks,URL_PhilPapers,Notes,Citations,ScholarURL,Edition,Status
+1997,Deleuze and Literature,Edited volume,Claire Colebrook,Edinburgh University Press,9780748612725,Affect,,https://edinburghuniversitypress.com/book-deleuze-and-literature,,,"",0,,1st,needs_verification
+2000,Michel de Certeau,Book,,SAGE Publications,9780761968967,Politics,,,,,"",0,,1st,confirmed
+2000,A Dictionary of Critical Theory,Book,,Oxford University Press,9780195126691,Pedagogy,,https://global.oup.com/academic/product/a-dictionary-of-critical-theory-9780195126691,,,"",250,https://scholar.google.com/scholar?q=A+Dictionary+of+Critical+Theory,1st,confirmed
+2000,Deleuzism: A Metacommentary,Book,,Duke University Press,9780822321813,Schizoanalysis;Assemblage,,https://www.dukeupress.edu/deleuzism,,,"",150,https://scholar.google.com/scholar?q=Deleuzism%3A+A+Metacommentary,,confirmed
+2004,Deleuze and the Schizoanalysis of Cinema,Edited volume,Patricia Pisters; Adrian Parr,Continuum,9780826479437,Schizoanalysis;Affect,,,,,"",85,https://scholar.google.com/scholar?q=Deleuze+and+the+Schizoanalysis+of+Cinema,,needs_verification
+2006,Fredric Jameson: Live Theory,Book,,Continuum,9780826461430,Politics;Marxism/Jameson;Pedagogy,,https://www.bloomsbury.com/us/fredric-jameson-9780826461430,,https://philpapers.org/rec/BUCFJL,"",210,https://scholar.google.com/scholar?q=Fredric+Jameson%3A+Live+Theory,1st,confirmed
+2008,"Deleuze and Guattari's ""Anti-Oedipus"": A Critical Introduction and Guide",Book,,Routledge,9781847064108,Schizoanalysis;Pedagogy,,,,,"",300,https://scholar.google.com/scholar?q=Deleuze+and+Guattari%27s+Anti-Oedipus,,confirmed
+2011,Deleuze and the Schizoanalysis of Cinema,Edited volume,Patricia Pisters,Bloomsbury,9781441173824,Schizoanalysis;Affect,,,,,"",70,https://scholar.google.com/scholar?q=Deleuze+and+the+Schizoanalysis+of+Cinema,,confirmed
+2013,Deleuze and the Schizoanalysis of Visual Culture,Edited volume,Laura Cull,Bloomsbury,9781780936708,Schizoanalysis;Affect,,,,,"",40,https://scholar.google.com/scholar?q=Deleuze+and+the+Schizoanalysis+of+Visual+Culture,,needs_verification
+2015,Assemblage and the Everyday,Article,,Deleuze Studies,,Assemblage,10.3366/dls.2015.0177,,,,"",145,https://scholar.google.com/scholar?q=Assemblage+and+the+Everyday,,confirmed
+2017,"Assemblage, Affect, and Art",Article,,Deleuze Studies,,Assemblage;Affect,10.3366/dls.2017.0265,,,,"",120,"https://scholar.google.com/scholar?q=Assemblage,+Affect,+and+Art",,needs_verification
+2017,The Incomplete Project of Schizoanalysis,Book,,Edinburgh University Press,9780748676122,Schizoanalysis,,,,,"",60,https://scholar.google.com/scholar?q=The+Incomplete+Project+of+Schizoanalysis,,confirmed
+2019,On Jameson,Book,,Haymarket Books,9781608469080,Marxism/Jameson,,,,,"",30,https://scholar.google.com/scholar?q=On+Jameson+Buchanan,,confirmed
+2021,Assemblage Theory and Method,Book,,Bloomsbury,978-1350014680,Assemblage;Pedagogy,,https://www.bloomsbury.com/9781350014680,https://books.google.com/books?vid=ISBN9781350014680,https://philpapers.org/rec/BUCAAT,"",320,https://scholar.google.com/scholar?q=Assemblage+Theory+and+Method,1st,confirmed

--- a/site/src/lib/audit.js
+++ b/site/src/lib/audit.js
@@ -1,0 +1,35 @@
+import Fuse from 'fuse.js'
+
+export function computeCoverage(rows) {
+  const total = rows.length
+  const byType = rows.reduce((m, r) => (m[r.type] = (m[r.type] || 0) + 1, m), {})
+  const isbnNeeded = rows.filter(r => ['Book', 'Edited volume'].includes(r.type))
+  const doiNeeded = rows.filter(r => ['Article', 'Chapter'].includes(r.type))
+
+  const pct = (n, d) => d ? Math.round((n / d) * 100) : 0
+
+  return {
+    total,
+    byType,
+    isbnFilledPct: pct(isbnNeeded.filter(r => (r.ISBN || '').trim()).length, isbnNeeded.length),
+    doiFilledPct: pct(doiNeeded.filter(r => (r.DOI || '').trim()).length, doiNeeded.length),
+    pubUrlPct: pct(rows.filter(r => (r.URL_Publisher || '').trim()).length, total)
+  }
+}
+
+export function missingQueues(rows) {
+  const needIsbn = rows.filter(r => ['Book', 'Edited volume'].includes(r.type) && !(r.ISBN || '').trim())
+  const needDoi = rows.filter(r => ['Article', 'Chapter'].includes(r.type) && !(r.DOI || '').trim())
+  const needUrl = rows.filter(r => !((r.URL_Publisher || r.URL_GoogleBooks || r.URL_PhilPapers || '').trim()))
+  const needVerify = rows.filter(r => (r.Status || '').trim() !== 'confirmed')
+
+  const fuse = new Fuse(rows, { keys: ['Title'], threshold: 0.28, ignoreLocation: true })
+  const dups = []
+  rows.forEach((r) => {
+    const hits = fuse.search(r.Title).map(h => h.item).filter(it =>
+      it !== r && it.Year === r.Year && it.Type === r.Type)
+    if (hits.length) dups.push({ ref: r, candidates: hits })
+  })
+
+  return { needIsbn, needDoi, needUrl, needVerify, dups }
+}

--- a/site/src/lib/csv.js
+++ b/site/src/lib/csv.js
@@ -26,13 +26,16 @@ export async function loadBibliography() {
         collaborators,
         venue: r.Publication?.trim(),
         isbn: (r.ISBN || '').trim(),
-        PublisherURL: r.PublisherURL,
-        GoogleBooksURL: r.GoogleBooksURL,
-        PhilPapersURL: r.PhilPapersURL,
+        PublisherURL: r.URL_Publisher,
+        GoogleBooksURL: r.URL_GoogleBooks,
+        PhilPapersURL: r.URL_PhilPapers,
         doi: r.DOI,
         tags,
         citations,
         ScholarURL: (r.ScholarURL || '').trim(),
+        notes: (r.Notes || '').trim(),
+        edition: (r.Edition || '').trim(),
+        status: (r.Status || '').trim(),
       }
     })
 }

--- a/site/src/main.jsx
+++ b/site/src/main.jsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import Audit from './pages/Audit.jsx'
+
+const Page = window.location.pathname.startsWith('/audit') ? Audit : App
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <Page />
   </StrictMode>,
 )

--- a/site/src/pages/Audit.jsx
+++ b/site/src/pages/Audit.jsx
@@ -1,0 +1,90 @@
+import React, { useMemo } from 'react'
+import Papa from 'papaparse'
+import { computeCoverage, missingQueues } from '../lib/audit.js'
+import { generateWiki } from '../lib/wiki.js'
+import bibliographyCsv from '../data/bibliography.csv?url'
+
+export default function Audit() {
+  const [rows, setRows] = React.useState([])
+  React.useEffect(() => {
+    fetch(bibliographyCsv).then(r => r.text()).then(t => {
+      const { data } = Papa.parse(t, { header: true, skipEmptyLines: true })
+      setRows(data.map(r => ({ ...r, type: r.Type })))
+    })
+  }, [])
+
+  const coverage = useMemo(() => computeCoverage(rows), [rows])
+  const queues = useMemo(() => missingQueues(rows), [rows])
+
+  const exportCsv = () => {
+    const csv = Papa.unparse(rows)
+    const blob = new Blob([csv], { type: 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'audit-export.csv'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const exportJson = () => {
+    const blob = new Blob([JSON.stringify(rows, null, 2)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'audit-export.json'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <div className="container">
+      <h1>Audit & Coverage</h1>
+
+      <div className="grid">
+        <div className="card"><strong>Total</strong><div>{coverage.total}</div></div>
+        <div className="card"><strong>Books</strong><div>{coverage.byType['Book']||0}</div></div>
+        <div className="card"><strong>Edited</strong><div>{coverage.byType['Edited volume']||0}</div></div>
+        <div className="card"><strong>Articles</strong><div>{coverage.byType['Article']||0}</div></div>
+        <div className="card"><strong>ISBN filled</strong><div>{coverage.isbnFilledPct}%</div></div>
+        <div className="card"><strong>DOI filled</strong><div>{coverage.doiFilledPct}%</div></div>
+        <div className="card"><strong>Has URL</strong><div>{coverage.pubUrlPct}%</div></div>
+      </div>
+
+      <div className="card" style={{marginTop:16}}>
+        <strong>Missing ISBN (Books/Edited)</strong>
+        <ul>{queues.needIsbn.map((r,i)=><li key={i}>{r.Year} — {r.Title}</li>)}</ul>
+      </div>
+
+      <div className="card">
+        <strong>Missing DOI (Articles/Chapters)</strong>
+        <ul>{queues.needDoi.map((r,i)=><li key={i}>{r.Year} — {r.Title}</li>)}</ul>
+      </div>
+
+      <div className="card">
+        <strong>No External URL</strong>
+        <ul>{queues.needUrl.map((r,i)=><li key={i}>{r.Year} — {r.Title}</li>)}</ul>
+      </div>
+
+      <div className="card">
+        <strong>Needs Verification (Status ≠ confirmed)</strong>
+        <ul>{queues.needVerify.map((r,i)=><li key={i}>{r.Year} — {r.Title} ({r.Status||'unset'})</li>)}</ul>
+      </div>
+
+      <div className="card">
+        <strong>Potential Duplicates (fuzzy)</strong>
+        <ul>{queues.dups.map((d,i)=>
+          <li key={i}>
+            {d.ref.Year} — {d.ref.Title}
+            <ul>{d.candidates.map((c,j)=><li key={j}>{c.Year} — {c.Title}</li>)}</ul>
+          </li>)}</ul>
+      </div>
+
+      <div style={{marginTop:20, display:'flex', gap:8, flexWrap:'wrap'}}>
+        <button className="button" onClick={() => navigator.clipboard.writeText(generateWiki(rows))}>Copy Wiki</button>
+        <button className="button" onClick={exportCsv}>Export CSV</button>
+        <button className="button" onClick={exportJson}>Export JSON</button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- expand bibliography.csv schema with DOI/URL/notes/status fields and updated metadata
- add audit.js utilities for coverage metrics and fuzzy duplicate detection
- create Audit.jsx dashboard with missing queues and export buttons; link via /audit route

## Testing
- `npm test` (missing script)
- `cd site && npm test` (missing script)
- `cd site && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0186aa5b4832b8604213423f25483