### PR TITLE
fix(audit): normalize type in duplicate detector

### DIFF
--- a/site/src/lib/audit.js
+++ b/site/src/lib/audit.js
@@ -27,7 +27,7 @@ export function missingQueues(rows) {
   const dups = []
   rows.forEach((r) => {
     const hits = fuse.search(r.Title).map(h => h.item).filter(it =>
-      it !== r && it.Year === r.Year && it.Type === r.Type)
+      it !== r && it.Year === r.Year && it.type === r.type)
     if (hits.length) dups.push({ ref: r, candidates: hits })
   })
 


### PR DESCRIPTION
## Summary
- ensure audit duplicate detector compares normalized type field

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b01a848780832b8fb72db2fb9f9784