### PR TITLE
feat(pipeline): publication pipeline + completeness sweep (Scholar, PhilPapers, Wiki imports)

### DIFF
--- a/site/src/App.jsx
+++ b/site/src/App.jsx
@@ -38,9 +38,11 @@ function ImportCard({ master }) {
 
   return (
     <div className="card">
-      <strong>Import & Merge (Scholar/PhilPapers)</strong>
+      <strong>Import & Merge (Scholar/PhilPapers/Wiki)</strong>
       <p className="small-muted">
-        Paste a simple CSV: <code>title,citations,url,year</code>
+        Paste a CSV: <code>title,citations,url,year,doi,philurl</code>. Scholar
+        gives first 4; PhilPapers adds DOIs/URLs; Wikipedia list at least has
+        title+year.
       </p>
       <textarea
         style={{ width: '100%', height: '120px', fontFamily: 'monospace' }}
@@ -52,7 +54,7 @@ function ImportCard({ master }) {
       </button>
       {report && (
         <p className="small-muted" style={{ marginTop: 6 }}>
-          Processed {report.count} entries. Additions: {report.additions.length}
+          Processed {report.count} rows · Additions: {report.additions.length}
         </p>
       )}
     </div>

--- a/site/src/lib/merge.js
+++ b/site/src/lib/merge.js
@@ -3,8 +3,17 @@ import Fuse from 'fuse.js'
 export function parseSimpleCSV(text) {
   const lines = text.split(/\r?\n/).filter(Boolean)
   return lines.map((line) => {
-    const [title, citations, url, year] = line.split(',').map((s) => s.trim())
-    return { title, citations: Number(citations) || '', url, year: Number(year) || '' }
+    const [title, citations, url, year, doi, philurl] = line
+      .split(',')
+      .map((s) => s.trim())
+    return {
+      title,
+      citations: citations ? Number(citations) : '',
+      url,
+      year: year ? Number(year) : '',
+      doi,
+      philurl,
+    }
   })
 }
 
@@ -17,6 +26,8 @@ export function mergeExternal(masterRows, extRows) {
     if (hit) {
       hit.Citations = ext.citations || hit.Citations
       hit.ScholarURL = ext.url || hit.ScholarURL
+      hit.DOI = ext.doi || hit.DOI
+      hit.URL_PhilPapers = ext.philurl || hit.URL_PhilPapers
       if (ext.year && /^\d{4}$/.test(String(ext.year))) hit.Year = hit.Year || ext.year
     } else {
       additions.push({
@@ -27,10 +38,10 @@ export function mergeExternal(masterRows, extRows) {
         Publication: '',
         ISBN: '',
         Tags: '',
-        DOI: '',
+        DOI: ext.doi || '',
         URL_Publisher: '',
         URL_GoogleBooks: '',
-        URL_PhilPapers: '',
+        URL_PhilPapers: ext.philurl || '',
         Notes: 'NEEDS TRIAGE (imported)',
         Citations: ext.citations || '',
         ScholarURL: ext.url || '',


### PR DESCRIPTION
## Summary
- expand merge helper to parse external CSVs with citations, DOIs, and PhilPapers links
- add import card UI to merge Scholar, PhilPapers, and Wikipedia lists into the master bibliography
- ensure bibliography CSV schema includes metadata columns for DOI, URLs, citations, and status

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b11cacea64832b8b7b783710862c0c