### PR TITLE
feat: add Vercel serverless functions

### DIFF
--- a/site/api/hello.js
+++ b/site/api/hello.js
@@ -1,0 +1,4 @@
+export default async function handler(req, res) {
+  res.setHeader('Cache-Control', 's-maxage=60');
+  res.status(200).json({ ok: true, msg: 'functions are working' });
+}

--- a/site/api/orcid.js
+++ b/site/api/orcid.js
@@ -1,16 +1,33 @@
 export default async function handler(req, res) {
   const orcid = (req.query.orcid || '0000-0003-4864-6495').trim();
   const base = `https://pub.orcid.org/v3.0/${orcid}`;
-  const headers = { Accept: 'application/json' };
+  const headers = {
+    'Accept': 'application/json',
+    'User-Agent': 'IanBuchananVault/1.0 (mailto:joesch22.js@gmail.com)'
+  };
 
   try {
-    const works = await fetch(`${base}/works`, { headers }).then(r => r.json());
-    const summaries = (works.group || []).flatMap(g => g['work-summary'] || []);
-    const details = await Promise.all(
-      summaries.map(s =>
-        fetch(`${base}/work/${s['put-code']}`, { headers }).then(r => r.json())
-      )
-    );
+    const worksResp = await fetch(`${base}/works`, { headers });
+    if (!worksResp.ok) throw new Error(`ORCID /works failed: ${worksResp.status}`);
+    const works = await worksResp.json();
+
+    const summaries = (works?.group || []).flatMap(g => g['work-summary'] || []);
+    if (!summaries.length) {
+      return res.status(200).json({
+        ok: true, source: 'orcid-api', orcid, count: 0, fetchedAt: new Date().toISOString(), rows: []
+      });
+    }
+
+    const detailPromises = summaries.map(s => {
+      const put = s?.['put-code'];
+      if (put === undefined || put === null) return null;
+      return fetch(`${base}/work/${put}`, { headers })
+        .then(r => (r.ok ? r.json() : null))
+        .catch(() => null);
+    }).filter(Boolean);
+
+    const details = (await Promise.all(detailPromises)).filter(Boolean);
+
     const rows = details.map(w => ({
       orcid_id: orcid,
       title: w?.title?.title?.value || '',
@@ -18,12 +35,15 @@ export default async function handler(req, res) {
       year: w?.['publication-date']?.year?.value || '',
       journal_or_publisher: w?.['journal-title']?.value || w?.publisher || '',
       doi: (w?.['external-ids']?.['external-id'] || [])
-             .find(e => e['external-id-type'] === 'doi')?.['external-id-value'] || '',
+        .find(e => e?.['external-id-type']?.toLowerCase() === 'doi')?.['external-id-value'] || '',
       url: (w?.['external-ids']?.['external-id'] || [])
-             .find(e => e['external-id-type'] === 'uri')?.['external-id-value'] || ''
+        .find(e => e?.['external-id-type']?.toLowerCase() === 'uri')?.['external-id-value'] || ''
     }));
+
     res.setHeader('Cache-Control', 's-maxage=3600, stale-while-revalidate');
-    res.status(200).json({ ok: true, source: 'orcid-api', orcid, count: rows.length, fetchedAt: new Date().toISOString(), rows });
+    res.status(200).json({
+      ok: true, source: 'orcid-api', orcid, count: rows.length, fetchedAt: new Date().toISOString(), rows
+    });
   } catch (e) {
     res.status(500).json({ ok: false, error: String(e) });
   }

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "api/**/*.js": {
+      "runtime": "nodejs18.x"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add /api/hello canary endpoint for health checks
- declare Node.js 18 runtime for Vercel serverless functions
- implement ORCID API endpoint to fetch and normalize works data

## Testing
- `npx eslint .`
- `npx vite build`

------
https://chatgpt.com/codex/tasks/task_e_68b2994c6630832bb9fc19f1e0820a4b