### PR TITLE
feat: improve mobile multi-select

### DIFF
--- a/site/src/components/MultiSelect.jsx
+++ b/site/src/components/MultiSelect.jsx
@@ -1,37 +1,104 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
-export default function MultiSelect({ label, items, idKey, labelKey, selected, onChange }) {
+export default function MultiSelect({
+  label,
+  items,
+  idKey,
+  labelKey,
+  selected,        // Set<string>
+  onChange,        // (Set<string>) => void
+  groupId,         // optional string to scope "Select all/None" to this list
+}) {
   const [open, setOpen] = useState(false);
-  useEffect(() => { if (!items?.length) setOpen(false); }, [items]);
+  const popRef = useRef(null);
+
+  // Close when clicking outside
+  useEffect(() => {
+    function onDoc(e){
+      if (!popRef.current) return;
+      if (!popRef.current.contains(e.target)) setOpen(false);
+    }
+    if (open) document.addEventListener('mousedown', onDoc, true);
+    return () => document.removeEventListener('mousedown', onDoc, true);
+  }, [open]);
+
+  const list = items ?? [];
+  const count = useMemo(() => {
+    let c = 0;
+    for (const it of list) if (selected.has(it[idKey])) c++;
+    return c;
+  }, [list, selected, idKey]);
+
+  function toggleOne(id) {
+    const next = new Set(selected);
+    next.has(id) ? next.delete(id) : next.add(id);
+    onChange(next);
+  }
+
+  function selectAllGroup() {
+    const next = new Set(selected);
+    for (const it of list) next.add(it[idKey]);        // UNION (not overwrite)
+    onChange(next);
+  }
+
+  function noneGroup() {
+    if (!list.length) return;
+    const ids = new Set(list.map(it => it[idKey]));
+    const next = new Set(Array.from(selected).filter(x => !ids.has(x))); // remove only this group's
+    onChange(next);
+  }
 
   return (
     <div style={{ position:'relative', display:'inline-block' }}>
-      <button className="btn" type="button" onClick={() => setOpen(!open)}>
-        {label} {selected.size ? `(${selected.size})` : ''}
+      <button
+        className="btn"
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+      >
+        {label} {count ? `(${count})` : ''}
       </button>
+
       {open && (
-        <div style={{
-          position:'absolute', zIndex:10, minWidth:260, maxWidth:320,
-          maxHeight:320, overflow:'auto', padding:8, background:'#fff',
-          border:'1px solid #ddd', boxShadow:'0 6px 14px rgba(0,0,0,.08)'
-        }}>
+        <div
+          ref={popRef}
+          role="listbox"
+          style={{
+            position:'absolute', zIndex:10, minWidth:260, maxWidth:340,
+            maxHeight:360, overflow:'auto', padding:8, background:'#fff',
+            border:'1px solid #ddd', boxShadow:'0 6px 14px rgba(0,0,0,.08)'
+          }}
+          // Prevent clicks inside from bubbling to parent (iOS safety)
+          onMouseDown={(e)=>e.stopPropagation()}
+          onClick={(e)=>e.stopPropagation()}
+        >
           <div style={{display:'flex', gap:8, marginBottom:6}}>
-            <button className="btn" onClick={() => onChange(new Set(items.map(x => x[idKey])))}>
-              Select all
-            </button>
-            <button className="btn" onClick={() => onChange(new Set())}>None</button>
+            <button className="btn" type="button" onClick={selectAllGroup}>Select all</button>
+            <button className="btn" type="button" onClick={noneGroup}>None</button>
           </div>
-          {items.map(it => {
+
+          {list.map(it => {
             const id = it[idKey];
             const name = it[labelKey];
             const active = selected.has(id);
             return (
-              <div key={id} style={{display:'flex', alignItems:'center', gap:8, padding:'4px 0'}}>
-                <input type="checkbox" checked={active} onChange={()=>{
-                  const next = new Set(selected);
-                  active ? next.delete(id) : next.add(id);
-                  onChange(next);
-                }} />
+              <div
+                key={id}
+                role="option"
+                aria-selected={active}
+                style={{
+                  display:'flex', alignItems:'center', gap:10,
+                  padding:'6px 4px', cursor:'pointer'
+                }}
+                onClick={(e) => { e.preventDefault(); toggleOne(id); }}
+              >
+                <input
+                  type="checkbox"
+                  checked={active}
+                  onChange={() => toggleOne(id)}
+                  onClick={(e)=>e.stopPropagation()}
+                />
                 <span>{name}</span>
               </div>
             );
@@ -41,3 +108,4 @@ export default function MultiSelect({ label, items, idKey, labelKey, selected, o
     </div>
   );
 }
+

--- a/site/src/pages/Compare.jsx
+++ b/site/src/pages/Compare.jsx
@@ -76,7 +76,11 @@ export default function Compare() {
   function applySelectedScholars() {
     const allMembers = scholarGroups.flatMap(g => g.members);
     const chosen = allMembers.filter(m => selScholars.has(m.orcid)).map(m => m.orcid);
-    setOrcids(chosen.join(', '));
+
+    // merge with what's already typed, remove duplicates
+    const existing = orcids.split(',').map(s=>s.trim()).filter(Boolean);
+    const merged = Array.from(new Set([...existing, ...chosen]));
+    setOrcids(merged.join(', '));
   }
 
   async function fetchData() {

--- a/site/src/pages/Graph.jsx
+++ b/site/src/pages/Graph.jsx
@@ -125,7 +125,11 @@ export default function Graph() {
   function applySelectedScholars() {
     const allMembers = scholarGroups.flatMap(g => g.members);
     const chosen = allMembers.filter(m => selScholars.has(m.orcid)).map(m => m.orcid);
-    setOrcids(chosen.join(', '));
+
+    // merge with what's already typed, remove duplicates
+    const existing = orcids.split(',').map(s=>s.trim()).filter(Boolean);
+    const merged = Array.from(new Set([...existing, ...chosen]));
+    setOrcids(merged.join(', '));
   }
 
   const filteredRows = useMemo(() => {


### PR DESCRIPTION
## Summary
- overhaul MultiSelect popover to avoid iOS tap bubbling and allow per-item, per-group selection
- merge selected scholars into existing ORCID list without duplicates in Compare and Graph views

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b2dc06c7bc832b83a4fcdf4842b0ad