### PR TITLE
Add ORCID and Wikipedia update guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Ian Buchanan Vault
+
+Resources related to Ian Buchanan's works.
+
+## Guides
+- [ORCID Verification Guide](docs/ORCID_Verification_Guide.md)
+- [Wikipedia Update Guide](docs/Wikipedia_Update_Guide.md)

--- a/docs/ORCID_Verification_Guide.md
+++ b/docs/ORCID_Verification_Guide.md
@@ -1,0 +1,25 @@
+# ORCID Verification Guide
+
+This guide explains how to verify ORCID iDs for scholars and update the Vault.
+
+## Steps
+1. Go to [https://orcid.org/](https://orcid.org/).
+2. Enter the scholar's full name in the search bar.
+3. Review results and confirm affiliation or field matches the scholar.
+4. Copy the full ORCID iD (format `0000-000X-XXXX-XXXX`).
+5. Paste the ID into `site/public/scholars/scholars.json` for the matching scholar.
+6. Include the ORCID profile link in your pull request description to document verification.
+
+### Example
+```json
+{
+  "name": "Ian Buchanan",
+  "orcid": "0000-0002-1825-0097"
+}
+```
+*Example ORCID record: [https://orcid.org/0000-0002-1825-0097](https://orcid.org/0000-0002-1825-0097)*
+
+## Checklist
+- [ ] Verified ORCID pasted into `scholars.json`.
+- [ ] PR description updated with ORCID link.
+- [ ] Ambiguous results noted as "No ORCID found".

--- a/docs/Wikipedia_Update_Guide.md
+++ b/docs/Wikipedia_Update_Guide.md
@@ -1,0 +1,43 @@
+# Wikipedia Update Guide
+
+This guide shows how to add Ian Buchanan's works to Wikipedia.
+
+## Rules
+- Use a neutral tone.
+- Cite reliable sources.
+- Follow correct wikitext formatting.
+
+## Steps
+1. Open [Ian Buchanan's Wikipedia page](https://en.wikipedia.org/wiki/Ian_Buchanan_(academic)) and click **Edit source**.
+2. Navigate to the *Selected works* section.
+3. Add books using the appropriate wikitext.
+
+### Example (Authored books)
+```wikitext
+===Authored books===
+* Buchanan, Ian (2000). ''Michel de Certeau: Cultural Theorist''. London: SAGE Publications. ISBN 978-0761952059.
+* Buchanan, Ian (2000). ''Deleuzism: A Metacommentary''. Edinburgh: Edinburgh University Press. ISBN 978-0748611879.
+* Buchanan, Ian (2006). ''Fredric Jameson: Live Theory''. London: Continuum. ISBN 978-0826463640.
+* Buchanan, Ian (2008). ''Deleuze and Guattari's ''Anti-Oedipus'': A Reader's Guide''. London: Continuum. ISBN 978-0826491483.
+* Buchanan, Ian (2020). ''Assemblage Theory and Method: An Introduction and Guide''. London: Bloomsbury Academic. ISBN 978-1350014680.
+* Buchanan, Ian (2021). ''The Incomplete Project of Schizoanalysis: Collected Essays on Deleuze and Guattari''. Edinburgh: Edinburgh University Press. ISBN 978-1474457669.
+```
+
+### Example (Edited books)
+```wikitext
+===Edited books===
+* Buchanan, Ian; Marks, John (2000). ''Deleuze and Literature''. Edinburgh: Edinburgh University Press.
+* Buchanan, Ian; Colebrook, Claire (2000). ''Deleuze and Feminist Theory''. Edinburgh: Edinburgh University Press.
+* Buchanan, Ian; Swiboda, Marcel (2004). ''Deleuze and Music''. Edinburgh: Edinburgh University Press.
+* Buchanan, Ian; Lambert, Gregg (2005). ''Deleuze and Space''. Edinburgh: Edinburgh University Press.
+* Buchanan, Ian; Parr, Adrian (2006). ''Deleuze and the Contemporary World''. Edinburgh: Edinburgh University Press.
+* Buchanan, Ian; Irr, Caren (2006). ''On Fredric Jameson''. Albany: SUNY Press.
+* Buchanan, Ian (ed.) (2007). ''Jameson on Jameson: Conversations on Cultural Marxism''. Durham: Duke University Press.
+* Buchanan, Ian; MacCormack, Patricia (2008). ''Deleuze and the Schizoanalysis of Cinema''. London: Continuum.
+* Buchanan, Ian; Thoburn, Nicholas (2008). ''Deleuze and Politics''. Edinburgh: Edinburgh University Press.
+```
+
+## Checklist
+- [ ] Works added in the correct section.
+- [ ] Preview checked before saving.
+- [ ] References cited properly.


### PR DESCRIPTION
## Summary
- add student-friendly ORCID verification instructions
- add Wikipedia update guide with copy-pasteable wikitext
- link guides from new README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd site && npm test` *(fails: Missing script: "test")*
- `curl -LH "Accept: application/json" "https://pub.orcid.org/v3.0/search?q=family-name:DeLanda+AND+given-names:Manuel"` *(fails: CONNECT tunnel failed, response 403)*
- `curl -I "https://en.wikipedia.org/wiki/Ian_Buchanan_(academic)"` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ea05e2c8832b8b36a1332f32f62c