### PR TITLE
feat: add Deleuzian scholars preset picker

### DIFF
--- a/site/public/data/scholars.json
+++ b/site/public/data/scholars.json
@@ -1,0 +1,13 @@
+[
+  { "name": "Ian Buchanan", "orcid": "0000-0003-4864-6495" },
+  { "name": "Claire Colebrook", "orcid": "TBD" },
+  { "name": "Brian Massumi",   "orcid": "TBD" },
+  { "name": "Manuel DeLanda",  "orcid": "TBD" },
+  { "name": "Rosi Braidotti",  "orcid": "TBD" },
+  { "name": "Eugene Holland",  "orcid": "TBD" },
+  { "name": "Patricia Pisters","orcid": "TBD" },
+  { "name": "Ronald Bogue",    "orcid": "TBD" },
+  { "name": "Gregg Lambert",   "orcid": "TBD" },
+  { "name": "Adrian Parr",     "orcid": "TBD" },
+  { "name": "John Protevi",    "orcid": "TBD" }
+]


### PR DESCRIPTION
## Summary
- add `/data/scholars.json` with initial Deleuzian scholars
- load scholar presets in Graph page and sync selections with ORCID input
- add multi-select picker to build graphs from preset scholars

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3626e47b0832b8d92ba8118b5a7aa