### PR TITLE
feat: add scholars settings page and API

### DIFF
--- a/site/api/scholars.js
+++ b/site/api/scholars.js
@@ -1,0 +1,48 @@
+/* eslint-env node */
+import { promises as fs } from 'fs';
+import path from 'path';
+import process from 'node:process';
+
+const filePath = path.join(process.cwd(), 'public', 'data', 'scholars.json');
+
+function isValidOrcid(id) {
+  return /^\d{4}-\d{4}-\d{4}-\d{3}[\dX]$/.test(id);
+}
+
+export default async function handler(req, res) {
+  if (req.method === 'GET') {
+    try {
+      const txt = await fs.readFile(filePath, 'utf8');
+      const data = JSON.parse(txt);
+      res.status(200).json(data);
+    } catch {
+      res.status(200).json([]);
+    }
+    return;
+  }
+
+  if (req.method === 'POST') {
+    try {
+      const body = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
+      if (!Array.isArray(body)) throw new Error('Expected an array');
+      const clean = body.map(s => ({
+        name: (s.name || '').trim(),
+        orcid: (s.orcid || '').trim()
+      })).filter(s => s.name);
+      for (const s of clean) {
+        if (s.orcid && !isValidOrcid(s.orcid)) {
+          return res.status(400).json({ ok: false, error: `Invalid ORCID for ${s.name}` });
+        }
+      }
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, JSON.stringify(clean, null, 2));
+      res.status(200).json({ ok: true, count: clean.length });
+    } catch (e) {
+      res.status(500).json({ ok: false, error: String(e) });
+    }
+    return;
+  }
+
+  res.setHeader('Allow', 'GET, POST');
+  res.status(405).end('Method Not Allowed');
+}

--- a/site/src/App.jsx
+++ b/site/src/App.jsx
@@ -4,6 +4,7 @@ import Bibliography from './pages/Bibliography.jsx';
 import Compare from './pages/Compare.jsx';
 import About from './pages/About.jsx';
 import Graph from './pages/Graph.jsx';
+import Scholars from './pages/Scholars.jsx';
 
 export default function App() {
   return (
@@ -14,6 +15,7 @@ export default function App() {
         <NavLink to="/bibliography" className={({isActive}) => isActive ? 'active' : ''}>Bibliography</NavLink>{' | '}
         <NavLink to="/compare" className={({isActive}) => isActive ? 'active' : ''}>Compare</NavLink>{' | '}
         <NavLink to="/graph" className={({isActive}) => isActive ? 'active' : ''}>Graph</NavLink>{' | '}
+        <NavLink to="/scholars" className={({isActive}) => isActive ? 'active' : ''}>Scholars</NavLink>{' | '}
         <NavLink to="/about" className={({isActive}) => isActive ? 'active' : ''}>About</NavLink>
       </nav>
 
@@ -22,6 +24,7 @@ export default function App() {
         <Route path="/bibliography" element={<Bibliography />} />
         <Route path="/compare" element={<Compare />} />
         <Route path="/graph" element={<Graph />} />
+        <Route path="/scholars" element={<Scholars />} />
         <Route path="/about" element={<About />} />
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/site/src/lib/loadLists.js
+++ b/site/src/lib/loadLists.js
@@ -1,15 +1,11 @@
 export async function loadScholars() {
-  const j = await fetch('/scholars/scholars.json').then(r => r.json());
-  // ensure structure: groups[].members[] with {id,name,orcid}
-  return (j.groups || []).map(g => ({
-    id: g.id,
-    label: g.label,
-    members: (g.members || []).map(m => ({
-      id: m.id,
-      name: m.name,
-      orcid: (m.orcid || '').trim()
-    }))
+  const list = await fetch('/api/scholars').then(r => r.json()).catch(() => []);
+  const members = (Array.isArray(list) ? list : []).map((s, i) => ({
+    id: (s.name || `scholar-${i}`).toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+    name: s.name,
+    orcid: (s.orcid || '').trim()
   }));
+  return [{ id: 'all', label: 'Scholars', members }];
 }
 
 export async function loadConcepts() {

--- a/site/src/pages/Graph.jsx
+++ b/site/src/pages/Graph.jsx
@@ -224,12 +224,12 @@ export default function Graph() {
   const [yearMax, setYearMax] = useState('');
   const [includeGlossary, setIncludeGlossary] = useState(true);
 
-  // Scholar presets (loaded from /data/scholars.json)
+  // Scholar presets (loaded from API)
   const [allScholars, setAllScholars] = useState([]);
   const [chosenScholars, setChosenScholars] = useState([]); // array of orcid strings
 
   useEffect(() => {
-    fetch('/data/scholars.json')
+    fetch('/api/scholars')
       .then(r => r.ok ? r.json() : [])
       .then(list => {
         // hide entries without a real ORCID

--- a/site/src/pages/Scholars.jsx
+++ b/site/src/pages/Scholars.jsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react';
+import Papa from 'papaparse';
+
+export default function Scholars() {
+  const [scholars, setScholars] = useState([]);
+  const [csvText, setCsvText] = useState('');
+
+  useEffect(() => {
+    fetch('/api/scholars')
+      .then(r => r.ok ? r.json() : [])
+      .then(setScholars)
+      .catch(() => setScholars([]));
+  }, []);
+
+  function updateField(i, key, value) {
+    const copy = [...scholars];
+    copy[i] = { ...copy[i], [key]: value };
+    setScholars(copy);
+  }
+
+  function addScholar() {
+    setScholars([...scholars, { name: '', orcid: '' }]);
+  }
+
+  function saveChanges() {
+    fetch('/api/scholars', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(scholars)
+    }).then(() => alert('Saved!'));
+  }
+
+  function exportCSV() {
+    const csv = Papa.unparse(scholars, { columns: ['name', 'orcid'] });
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = 'scholars.csv'; a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function parseRows(data) {
+    const rows = (data || []).map(r => ({
+      name: r.name || '',
+      orcid: r.orcid || ''
+    })).filter(r => r.name);
+    setScholars(rows);
+  }
+
+  function importCSV(e) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    Papa.parse(file, {
+      header: true,
+      skipEmptyLines: true,
+      complete: (res) => parseRows(res.data)
+    });
+  }
+
+  function importCSVText() {
+    Papa.parse(csvText, {
+      header: true,
+      skipEmptyLines: true,
+      complete: (res) => parseRows(res.data)
+    });
+  }
+
+  return (
+    <div style={{padding:'2rem'}}>
+      <h1>Scholars Settings</h1>
+      <table>
+        <thead><tr><th>Name</th><th>ORCID</th></tr></thead>
+        <tbody>
+          {scholars.map((s,i) => (
+            <tr key={i} style={{opacity: s.orcid ? 1 : 0.5}}>
+              <td>
+                <input
+                  value={s.name}
+                  onChange={e=>updateField(i,'name',e.target.value)}
+                />
+              </td>
+              <td>
+                <input
+                  value={s.orcid || ''}
+                  placeholder="TBD"
+                  onChange={e=>updateField(i,'orcid',e.target.value)}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div style={{display:'flex', gap:8, flexWrap:'wrap', marginTop:12}}>
+        <button onClick={saveChanges}>Save Changes</button>
+        <button onClick={addScholar}>Add Scholar</button>
+        <button onClick={exportCSV}>Export CSV</button>
+        <input type="file" accept=".csv" onChange={importCSV} />
+        <textarea
+          placeholder="Paste CSV here"
+          value={csvText}
+          onChange={e=>setCsvText(e.target.value)}
+          rows={3}
+          style={{width:'100%'}}
+        />
+        <button onClick={importCSVText}>Import CSV Text</button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `/api/scholars` for retrieving and saving the scholars list
- add `/scholars` page with editable table, CSV import/export, and add/save actions
- load scholars for graph and compare via new API and expose link in site nav

## Testing
- `cd site && yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68b3637be1a4832b857c2518e533bdd5