### PR TITLE
Add GitHub-backed persistence for concepts and scholars

### DIFF
--- a/site/api/_github.js
+++ b/site/api/_github.js
@@ -1,0 +1,67 @@
+/* eslint-env node */
+/* global process Buffer */
+
+export async function ghRequest(path, init = {}) {
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPO;
+  if (!token || !repo) throw new Error('GitHub not configured.');
+
+  const url = `https://api.github.com/repos/${repo}/${path}`;
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Accept': 'application/vnd.github+json',
+      'User-Agent': 'Buchanan-Vault',
+      ...(init.headers || {})
+    }
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(()=> '');
+    throw new Error(`GitHub ${res.status}: ${text || res.statusText}`);
+  }
+  return res.json();
+}
+
+export async function getBranchSha(branch) {
+  const data = await ghRequest(`git/ref/heads/${branch}`);
+  return data.object.sha;
+}
+
+export async function getFileSha(branch, path) {
+  try {
+    const file = await ghRequest(`contents/${path}?ref=${branch}`);
+    return file.sha;
+  } catch {
+    return null;
+  }
+}
+
+export async function createBranch(fromBranch, newBranch) {
+  const sha = await getBranchSha(fromBranch);
+  return ghRequest('git/refs', {
+    method: 'POST',
+    body: JSON.stringify({ ref: `refs/heads/${newBranch}`, sha })
+  });
+}
+
+export async function putFileOnBranch(branch, filepath, contentJson, message) {
+  const content = Buffer.from(JSON.stringify(contentJson, null, 2)).toString('base64');
+  const sha = await getFileSha(branch, filepath);
+  return ghRequest(`contents/${filepath}`, {
+    method: 'PUT',
+    body: JSON.stringify({
+      message,
+      content,
+      branch,
+      ...(sha ? { sha } : {})
+    })
+  });
+}
+
+export async function openPR(fromBranch, toBranch, title, body) {
+  return ghRequest('pulls', {
+    method: 'POST',
+    body: JSON.stringify({ head: fromBranch, base: toBranch, title, body })
+  });
+}

--- a/site/api/save-config.js
+++ b/site/api/save-config.js
@@ -1,0 +1,66 @@
+/* eslint-env node */
+/* global process */
+import { createBranch, openPR, putFileOnBranch } from './_github.js';
+
+const FILES = {
+  concepts: 'site/public/data/concepts.json',
+  scholars: 'site/public/data/scholars.json'
+};
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ ok:false, error:'POST required' }); return;
+  }
+
+  const { kind, payload, message, direct } = await readJson(req);
+  const filepath = FILES[kind];
+  if (!filepath) { res.status(400).json({ ok:false, error:'Unknown kind' }); return; }
+
+  const isProd = process.env.VERCEL_ENV === 'production';
+  const preferDirect = direct || process.env.GITHUB_COMMIT_MODE === 'direct';
+
+  try {
+    if (!isProd) {
+      // dev: write to fs like before for convenience
+      const fs = await import('fs'); const path = await import('path');
+      const file = path.join(process.cwd(), filepath);
+      fs.writeFileSync(file, JSON.stringify(payload, null, 2), 'utf8');
+      res.status(200).json({ ok:true, mode:'dev-fs' });
+      return;
+    }
+
+    // production: GitHub
+    const repo = process.env.GITHUB_REPO;
+    if (!process.env.GITHUB_TOKEN || !repo) {
+      // Optionally, fall back to Blob here; else fail with message
+      res.status(501).json({ ok:false, error:'GitHub not configured in production (GITHUB_TOKEN,GITHUB_REPO).' });
+      return;
+    }
+
+    const base = process.env.GITHUB_DEFAULT_BRANCH || 'main';
+    const stamp = new Date().toISOString().replace(/[:.]/g,'-');
+    const branch = `vault/update-${kind}-${stamp}`;
+
+    if (!preferDirect) {
+      await createBranch(base, branch);
+      await putFileOnBranch(branch, filepath, payload, message || `Update ${kind}.json via UI`);
+      const pr = await openPR(branch, base, `Vault: update ${kind}.json`, `Automated update from Vault UI at ${new Date().toISOString()}`);
+      res.status(200).json({ ok:true, mode:'github-pr', url: pr.html_url });
+      return;
+    } else {
+      // Direct commit onto base (less safe)
+      await putFileOnBranch(base, filepath, payload, message || `Update ${kind}.json via UI`);
+      res.status(200).json({ ok:true, mode:'github-direct', url:`https://github.com/${repo}/commits/${base}` });
+      return;
+    }
+  } catch (e) {
+    res.status(500).json({ ok:false, error: String(e.message || e) });
+  }
+}
+
+function readJson(req) {
+  return new Promise((resolve, reject) => {
+    let data=''; req.on('data', c=> data+=c);
+    req.on('end', ()=> { try { resolve(JSON.parse(data||'{}')); } catch(e){ reject(e); }});
+  });
+}

--- a/site/src/pages/Concepts.jsx
+++ b/site/src/pages/Concepts.jsx
@@ -4,7 +4,6 @@ import { Link } from 'react-router-dom';
 export default function Concepts() {
   const [concepts, setConcepts] = useState([]);
   const [saving, setSaving] = useState(false);
-  const isProd = import.meta.env.PROD;
 
   useEffect(() => {
     fetch('/api/concepts').then(r => r.json()).then(setConcepts).catch(()=>setConcepts([]));
@@ -15,16 +14,16 @@ export default function Concepts() {
   }
 
   async function save() {
-    if (isProd) { alert('Saving disabled on production build.'); return; }
     setSaving(true);
-    const resp = await fetch('/api/concepts', {
+    const resp = await fetch('/api/save-config', {
       method:'POST',
       headers:{'Content-Type':'application/json'},
-      body: JSON.stringify(concepts)
+      body: JSON.stringify({ kind:'concepts', payload: concepts, message:'Update concepts via Concepts UI' })
     });
     setSaving(false);
-    if (resp.ok) alert('Saved (dev). In production, use GitHub/Blob for persistence.');
-    else alert('Save failed.');
+    const j = await resp.json();
+    if (j.ok) alert(`Saved (${j.mode}). ${j.url ? 'Open: '+j.url : ''}`);
+    else alert('Save failed: ' + j.error);
   }
 
   return (
@@ -65,11 +64,8 @@ export default function Concepts() {
 
       <div style={{display:'flex', gap:8, marginTop:12}}>
         <button className="btn" onClick={addConcept}>Add Concept</button>
-        <button className="btn primary" onClick={save} disabled={saving}>{saving?'Saving…':'Save (dev only)'}</button>
+        <button className="btn primary" onClick={save} disabled={saving}>{saving?'Saving…':'Save'}</button>
       </div>
-      <p style={{opacity:.7, marginTop:8}}>
-        Writes are disabled on production (Vercel read-only FS). For prod persistence, wire GitHub API or Vercel Blob/KV.
-      </p>
     </div>
   );
 

--- a/site/src/pages/Scholars.jsx
+++ b/site/src/pages/Scholars.jsx
@@ -4,6 +4,7 @@ import Papa from 'papaparse';
 export default function Scholars() {
   const [scholars, setScholars] = useState([]);
   const [csvText, setCsvText] = useState('');
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     fetch('/api/scholars')
@@ -22,12 +23,17 @@ export default function Scholars() {
     setScholars([...scholars, { name: '', orcid: '' }]);
   }
 
-  function saveChanges() {
-    fetch('/api/scholars', {
+  async function saveChanges() {
+    setSaving(true);
+    const resp = await fetch('/api/save-config', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(scholars)
-    }).then(() => alert('Saved!'));
+      body: JSON.stringify({ kind: 'scholars', payload: scholars, message: 'Update scholars via Scholars UI' })
+    });
+    setSaving(false);
+    const j = await resp.json();
+    if (j.ok) alert(`Saved (${j.mode}). ${j.url ? 'Open: ' + j.url : ''}`);
+    else alert('Save failed: ' + j.error);
   }
 
   function exportCSV() {
@@ -92,7 +98,7 @@ export default function Scholars() {
       </table>
 
       <div style={{display:'flex', gap:8, flexWrap:'wrap', marginTop:12}}>
-        <button onClick={saveChanges}>Save Changes</button>
+        <button onClick={saveChanges} disabled={saving}>{saving ? 'Saving…' : 'Save Changes'}</button>
         <button onClick={addScholar}>Add Scholar</button>
         <button onClick={exportCSV}>Export CSV</button>
         <input type="file" accept=".csv" onChange={importCSV} />


### PR DESCRIPTION
## Summary
- Add GitHub client utility to create branches, commit JSON updates, and open PRs
- Provide `/api/save-config` endpoint to write concepts/scholars to GitHub or local filesystem
- Update Concepts and Scholars pages to save through the new endpoint with success messaging

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b36be10674832bb032fe434137faae