### PR TITLE
fix: configure ORCID API proxy base

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,5 +5,8 @@ GOOGLEBOOKS_BASE=https://www.googleapis.com/books/v1
 GOOGLEBOOKS_KEY=
 PHILPAPERS_BASE=https://philpapers.org
 
+# Backend API base for frontend requests
+VITE_API_BASE=http://localhost:8787/api/orcid
+
 # Default ORCID to load (overrideable in UI)
 VITE_DEFAULT_ORCID=0000-0002-1825-0097

--- a/server/biblioRoutes.js
+++ b/server/biblioRoutes.js
@@ -2,20 +2,24 @@ const { fetchOrcidWorks } = require('./clients/orcid.js');
 
 module.exports = async function biblioRoutes(req, res) {
   const url = new URL(req.url, `http://${req.headers.host}`);
-  if (req.method === 'GET' && url.pathname.startsWith('/api/orcid/')) {
-    const id = url.pathname.split('/')[3];
-    if (url.pathname.endsWith('/works')) {
+
+  if (req.method === 'GET') {
+    const match = url.pathname.match(/^\/api\/orcid\/([^/]+)\/works$/);
+    if (match) {
       try {
-        const works = await fetchOrcidWorks(id);
+        const works = await fetchOrcidWorks(match[1]);
         res.setHeader('Content-Type', 'application/json');
-        res.end(JSON.stringify(works));
+        res.end(JSON.stringify({ works }));
       } catch (err) {
         res.statusCode = 500;
+        res.setHeader('Content-Type', 'application/json');
         res.end(JSON.stringify({ error: String(err) }));
       }
       return;
     }
   }
+
   res.statusCode = 404;
-  res.end('Not found');
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify({ error: 'Not found' }));
 };

--- a/site/src/lib/orcidClient.js
+++ b/site/src/lib/orcidClient.js
@@ -1,8 +1,9 @@
-const BASE = '/api/orcid';
+const BASE =
+  import.meta.env.VITE_API_BASE || 'http://localhost:8787/api/orcid';
 
 export async function fetchOrcidWorks(id) {
   const res = await fetch(`${BASE}/${id}/works`);
   if (!res.ok) throw new Error('Failed to fetch ORCID');
   const data = await res.json();
-  return data.works || [];
+  return data.works || data;
 }


### PR DESCRIPTION
## Summary
- ensure ORCID proxy route returns structured JSON and 404s as JSON
- allow frontend to specify API base URL via `VITE_API_BASE`
- document API base in env example

## Testing
- `npm --prefix site run lint`
- `node server/index.js & curl -s -o /tmp/orcid.json http://localhost:8787/api/orcid/0000-0002-1825-0097/works`


------
https://chatgpt.com/codex/tasks/task_e_68b3854e49b4832b933302c6e9ecbedd