### PR TITLE
feat(know): Know widget + /api/know/v1 wiring

### DIFF
--- a/site/.env.example
+++ b/site/.env.example
@@ -1,2 +1,2 @@
-VITE_KNOW_API_BASE=https://<render-app>.onrender.com/api/know/v1
-VITE_KNOW_SITE_ID=buchanan-vault
+VITE_KNOW_API_BASE=
+VITE_DEFAULT_SITE_ID=buchanan-vault

--- a/site/src/lib/knowClient.ts
+++ b/site/src/lib/knowClient.ts
@@ -1,0 +1,38 @@
+export type ToolDef = { name: string; description?: string; schema?: any; confirm?: boolean; };
+
+export type QueryResponse =
+  | { answer: string; citations?: { title: string; url: string }[] }
+  | {
+      needsTool: true;
+      call: { name: string; args?: Record<string, any> };
+      confirm?: boolean;
+      draft?: string;
+      answer?: string;
+      citations?: { title: string; url: string }[];
+    };
+
+export class KnowClient {
+  constructor(
+    private base = import.meta.env.VITE_KNOW_API_BASE as string,
+    private siteId = import.meta.env.VITE_DEFAULT_SITE_ID as string
+  ) {
+    if (!this.base) throw new Error("VITE_KNOW_API_BASE missing");
+    if (!this.siteId) throw new Error("VITE_DEFAULT_SITE_ID missing");
+  }
+
+  async tools(siteId = this.siteId): Promise<ToolDef[]> {
+    const r = await fetch(`${this.base}/tools?siteId=${encodeURIComponent(siteId)}`);
+    if (!r.ok) throw new Error(`tools(): ${r.status}`);
+    return r.json();
+  }
+
+  async query(msg: string, siteId = this.siteId): Promise<QueryResponse> {
+    const r = await fetch(`${this.base}/query`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ siteId, msg })
+    });
+    if (!r.ok) throw new Error(`query(): ${r.status}`);
+    return r.json();
+  }
+}

--- a/site/src/lib/knowTools.ts
+++ b/site/src/lib/knowTools.ts
@@ -1,0 +1,34 @@
+export type ToolCall = { name: string; args?: Record<string, any> };
+
+export async function runTool(call: ToolCall): Promise<{ ok: boolean; message?: string }> {
+  const { name, args = {} } = call;
+
+  if (name === "openBibliography") {
+    const params = new URLSearchParams();
+    if (args.query) params.set("q", String(args.query));
+    if (args.type) params.set("type", String(args.type));
+    if (args.yearMin) params.set("ymin", String(args.yearMin));
+    if (args.yearMax) params.set("ymax", String(args.yearMax));
+    const href = `/bibliography${params.toString() ? `?${params.toString()}` : ""}`;
+    window.location.assign(href);
+    return { ok: true, message: "Opening Bibliography…" };
+  }
+
+  if (name === "copyWikiBlock") {
+    const text = String(args.selection || "");
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // fallback for iOS/webviews
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand("copy");
+      document.body.removeChild(ta);
+    }
+    return { ok: true, message: "Copied to clipboard." };
+  }
+
+  return { ok: false, message: `Unknown tool: ${name}` };
+}

--- a/site/src/main.jsx
+++ b/site/src/main.jsx
@@ -3,6 +3,19 @@ import { BrowserRouter } from 'react-router-dom'
 import App from './App.jsx'
 import './styles/global.css'
 
+// --- Know widget mount (auto-added by CWO) ---
+import "@/widgets/knowWidget.css";
+import { KnowWidget } from "@/widgets/KnowWidget";
+
+(function mountKnow(){
+  if (typeof window === "undefined") return;
+  window.addEventListener("DOMContentLoaded", () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    new KnowWidget(host, { welcome: "Hi! Ask about bibliography, formatting, or wiki blocks." });
+  });
+})();
+
 createRoot(document.getElementById('root')).render(
   <BrowserRouter>
     <App />

--- a/site/src/widgets/KnowWidget.ts
+++ b/site/src/widgets/KnowWidget.ts
@@ -1,0 +1,70 @@
+import { KnowClient, QueryResponse } from "@/lib/knowClient";
+import { runTool } from "@/lib/knowTools";
+
+type Opts = { siteId?: string; welcome?: string };
+
+export class KnowWidget {
+  private root!: HTMLElement; private panel!: HTMLElement; private log!: HTMLElement;
+  private input!: HTMLInputElement; private sendBtn!: HTMLButtonElement;
+  private client: KnowClient;
+
+  constructor(container: HTMLElement, opts: Opts = {}) {
+    this.client = new KnowClient(undefined, opts.siteId);
+    this.mount(container, opts.welcome ?? "Ask about bibliography, formatting, or Wikipedia blocks.");
+  }
+
+  private mount(container: HTMLElement, welcome: string) {
+    this.root = document.createElement("div");
+    this.root.className = "kb-root";
+    this.root.innerHTML = `
+      <button class="kb-fab" aria-label="Open Know chat">?</button>
+      <div class="kb-panel" hidden>
+        <div class="kb-head"><strong>Know</strong><button class="kb-close" aria-label="Close">×</button></div>
+        <div class="kb-log" role="log" aria-live="polite"></div>
+        <form class="kb-form">
+          <input class="kb-input" placeholder="Ask a question…" autocomplete="off" />
+          <button class="kb-send" type="submit">Send</button>
+        </form>
+      </div>`;
+    container.appendChild(this.root);
+    this.panel = this.root.querySelector(".kb-panel")!;
+    this.log = this.root.querySelector(".kb-log")!;
+    this.input = this.root.querySelector(".kb-input")!;
+    this.sendBtn = this.root.querySelector(".kb-send")!;
+
+    const fab = this.root.querySelector(".kb-fab")!; const close = this.root.querySelector(".kb-close")!;
+    fab.addEventListener("click", () => (this.panel.hidden = false));
+    close.addEventListener("click", () => (this.panel.hidden = true));
+
+    (this.root.querySelector(".kb-form") as HTMLFormElement).onsubmit = (e) => {
+      e.preventDefault(); const msg = this.input.value.trim(); if (msg) this.ask(msg); this.input.value = "";
+    };
+
+    this.appendBot(welcome);
+  }
+
+  private appendUser(t: string){ this.addMsg(t,"kb-user"); }
+  private appendBot(t: string){ this.addMsg(t,"kb-bot"); }
+  private appendNote(t: string){ this.addMsg(t,"kb-note"); }
+  private addMsg(t: string, cls: string){
+    const el=document.createElement("div"); el.className="kb-msg "+cls; el.textContent=t;
+    this.log.appendChild(el); this.log.scrollTop=this.log.scrollHeight;
+  }
+
+  async ask(msg: string) {
+    this.appendUser(msg); this.sendBtn.disabled = true;
+    try {
+      const res: QueryResponse = await this.client.query(msg);
+      if ("needsTool" in res && res.needsTool) {
+        if (res.draft) this.appendBot(res.draft);
+        const execute = async()=>{const out=await runTool(res.call);this.appendNote(out.message||"");};
+        if (res.confirm && !window.confirm(res.draft||"Proceed?")) this.appendNote("Cancelled."); else await execute();
+        if (res.answer) this.appendBot(res.answer);
+      } else {
+        this.appendBot(res.answer);
+        if (res.citations?.length) this.appendNote("Sources: "+res.citations.map(c=>c.title).join(", "));
+      }
+    } catch(e:any){ this.appendNote(`Error: ${e?.message||String(e)}`); }
+    finally{ this.sendBtn.disabled = false; }
+  }
+}

--- a/site/src/widgets/knowWidget.css
+++ b/site/src/widgets/knowWidget.css
@@ -1,0 +1,15 @@
+:root{ --kb-accent: var(--brand-accent,#C7A43A); --kb-radius:12px; --kb-bg:#111; --kb-fg:#f5f5f5; }
+.kb-root{ position:fixed; right:16px; bottom:16px; z-index:9999; }
+.kb-fab{ border:0; border-radius:var(--kb-radius); padding:10px 14px; background:var(--kb-accent); color:#000;
+  font-weight:700; box-shadow:0 6px 18px rgba(0,0,0,.25); cursor:pointer;}
+.kb-panel{ position:fixed; right:16px; bottom:72px; width:min(380px,calc(100vw - 32px)); max-height:520px;
+  display:flex; flex-direction:column; border-radius:var(--kb-radius); background:var(--kb-bg); color:var(--kb-fg);
+  box-shadow:0 12px 28px rgba(0,0,0,.35);}
+.kb-head{ display:flex; justify-content:space-between; padding:8px 12px; border-bottom:1px solid rgba(255,255,255,.1);}
+.kb-log{ flex:1; padding:12px; overflow:auto; display:flex; flex-direction:column; gap:6px;}
+.kb-msg{ font-size:14px; line-height:1.4; padding:8px 10px; border-radius:10px; background:rgba(255,255,255,.06);}
+.kb-user{ align-self:flex-end; background:rgba(255,255,255,.12);}
+.kb-note{ font-size:12px; opacity:.8; background:none; padding:0;}
+.kb-form{ display:flex; gap:8px; padding:10px; border-top:1px solid rgba(255,255,255,.1);}
+.kb-input{ flex:1; padding:8px 10px; border-radius:8px; border:1px solid rgba(255,255,255,.2); background:#0002; color:var(--kb-fg);}
+.kb-send{ padding:8px 12px; border-radius:8px; border:0; background:var(--kb-accent); color:#000; font-weight:700; cursor:pointer;}


### PR DESCRIPTION
• Adds knowClient, knowTools, KnowWidget, and CSS.
• Mounts a small floating “Know” chat bubble site-wide.
• Reads VITE_KNOW_API_BASE + VITE_DEFAULT_SITE_ID.
• Handles client tools: openBibliography, copyWikiBlock.
• Manual tests:
1. “open bibliography for assemblage 2000–2010” → navigates with params
2. “copy wikipedia block” → confirm + clipboard
3. “what is assemblage?” → stub answer + Sources note
• After merge, set in Vercel:

VITE_KNOW_API_BASE=https://<your-codecrafter-render>.onrender.com/api/know/v1
VITE_DEFAULT_SITE_ID=buchanan-vault


• Post back: exact env values used, 20-sec Loom/GIF of the 3 tests, and any console/CORS issues.

Acceptance Criteria (for Codex to include in PR description)
• Widget renders on production + preview.
• POST {base}/query & GET {base}/tools return 200.
• Tool flows work (navigate + clipboard).
• No console errors; CORS succeeds from Vercel domains.

------
https://chatgpt.com/codex/tasks/task_e_68b3a01a8a60832b905b2d059fefe390