### PR TITLE
fix(build): correct know widget paths & mount (site/src, @ alias)

### DIFF
--- a/site/src/main.jsx
+++ b/site/src/main.jsx
@@ -9,10 +9,13 @@ createRoot(document.getElementById('root')).render(
   <BrowserRouter>
     <App />
   </BrowserRouter>
-)
+);
 
+// --- Know widget mount (auto-added by CWO) ---
 (function mountKnow(){
   if (typeof window === "undefined") return;
+  if (window.__KNOW_WIDGET_MOUNTED__) return;
+  window.__KNOW_WIDGET_MOUNTED__ = true;
   window.addEventListener("DOMContentLoaded", () => {
     const host = document.createElement("div");
     document.body.appendChild(host);


### PR DESCRIPTION
- Creates site/src/widgets/* and site/src/lib/* with Know widget + client.
- Ensures imports in site/src/main.jsx resolve via @ → site/src.
- Appends guarded mount block (no duplicate instances).
- No changes to bibliography/ORCID endpoints or logic.

Acceptance Criteria:
- Vercel build succeeds (no “failed to resolve @/widgets/knowWidget.css”).
- Widget bubble renders locally & on preview.
- Bibliography fetching remains unchanged.

------
https://chatgpt.com/codex/tasks/task_e_68b3b7610a14832b8a943ffc7c73a839