### PR TITLE
fix(know): close/minimize now works (hidden respected)

### DIFF
--- a/site/src/widgets/KnowWidget.ts
+++ b/site/src/widgets/KnowWidget.ts
@@ -116,6 +116,7 @@ export class KnowWidget {
     this.isOpen = true;
     this.openScrollY = window.scrollY;
     sessionStorage.setItem(KB_STATE_KEY, "true");
+    this.fab?.setAttribute("aria-expanded", String(this.isOpen));
     // focus input without jumping viewport on mobile
     setTimeout(() => this.input?.focus({ preventScroll: true }), 0);
   }
@@ -125,6 +126,7 @@ export class KnowWidget {
     this.panel.hidden = true;
     this.isOpen = false;
     sessionStorage.setItem(KB_STATE_KEY, "false");
+    this.fab?.setAttribute("aria-expanded", String(this.isOpen));
   }
 
   private appendUser(t: string) { this.addMsg(t, "kb-user"); }

--- a/site/src/widgets/knowWidget.css
+++ b/site/src/widgets/knowWidget.css
@@ -19,3 +19,8 @@
   background:transparent; border:0; color:var(--kb-fg); font-size:18px; cursor:pointer; line-height:1;
 }
 .kb-head .kb-min:hover, .kb-head .kb-close:hover { opacity:.85; }
+
+/* Ensure the panel actually hides when `hidden` is set */
+.kb-panel[hidden] {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary
- Adds CSS rule so .kb-panel[hidden] uses display:none !important.
- Ensures close/minimize/ESC/tap-outside now collapse the panel visually.
- (Optional) Updates FAB to reflect aria-expanded state for accessibility.
- No backend changes, safe to merge/deploy.

## Testing
- `yarn lint` *(fails: __dirname is not defined in site/vite.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ceb22e90832bacb24c0a8c431eca