### PR TITLE
feat: add trainer form with GitHub PR submission

### DIFF
--- a/site/api/forms/submit-qa.ts
+++ b/site/api/forms/submit-qa.ts
@@ -1,0 +1,139 @@
+// Vercel Node runtime (for multipart)
+export const config = { runtime: "node" };
+
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { Octokit } from "octokit";
+import Busboy from "busboy";
+import crypto from "crypto";
+
+function slug(s: string) {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g,"-").replace(/(^-|-$)/g,"");
+}
+function json(res: VercelResponse, body: any, status = 200) {
+  res.status(status).setHeader("Content-Type","application/json").send(JSON.stringify(body));
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    if (req.method !== "POST") return json(res, { error: "Method not allowed" }, 405);
+
+    // Basic origin/CSRF check
+    const allowed = process.env.SUBMIT_ALLOWED_ORIGIN;
+    const origin = req.headers.origin || "";
+    if (allowed && !origin.startsWith(allowed)) {
+      return json(res, { error: "Bad origin" }, 403);
+    }
+
+    // Parse multipart form
+    const fields: Record<string,string> = {};
+    let fileBuf: Buffer | null = null;
+    let fileName = "";
+    const bb = Busboy({ headers: req.headers });
+
+    const done = new Promise<void>((resolve, reject) => {
+      bb.on("file", (_name, file, info) => {
+        const { filename } = info;
+        const chunks: Buffer[] = [];
+        file.on("data", (d: Buffer) => chunks.push(d));
+        file.on("end", () => {
+          fileBuf = Buffer.concat(chunks);
+          fileName = filename || "upload.pdf";
+        });
+      });
+      bb.on("field", (name, val) => { fields[name] = String(val); });
+      bb.on("error", reject);
+      bb.on("finish", resolve);
+    });
+
+    req.pipe(bb);
+    await done;
+
+    const question = (fields["question"] || "").trim();
+    const answer = (fields["answer"] || "").trim();
+    const transcript = (fields["transcript"] || "").trim();
+    const tags = (fields["tags"] || "").split(",").map(s=>s.trim()).filter(Boolean);
+
+    if (!question || (!answer && !transcript && !fileBuf)) {
+      return json(res, { error: "Provide at least one of: answer, transcript, file" }, 400);
+    }
+
+    // Validate file size/type
+    if (fileBuf) {
+      const maxMb = Number(process.env.MAX_UPLOAD_MB || 20);
+      if (fileBuf.byteLength > maxMb * 1024 * 1024) {
+        return json(res, { error: `File too large (> ${maxMb}MB)` }, 400);
+      }
+      const allowed = (process.env.ALLOWED_FILE_TYPES || ".pdf,.txt,.md").split(",").map(s=>s.trim().toLowerCase());
+      const ext = "." + (fileName.split(".").pop() || "").toLowerCase();
+      if (!allowed.includes(ext)) return json(res, { error: `File type not allowed (${ext})` }, 400);
+    }
+
+    // Build entry JSON
+    const date = new Date().toISOString().slice(0,10);
+    const id = `qa-${date}-${slug(question).slice(0,60)}`;
+    const entry: any = {
+      id, question,
+      answer: answer || transcript || null,
+      author: "Ian Buchanan",
+      date,
+      source: transcript ? "voice-transcript" : (fileBuf ? "pdf" : "text"),
+      tags
+    };
+
+    // Prepare Git objects
+    const owner = process.env.GH_REPO_OWNER!;
+    const repo = process.env.GH_REPO_NAME!;
+    const base = process.env.GH_DEFAULT_BRANCH || "main";
+    const token = process.env.GH_REPO_TOKEN!;
+    const octo = new Octokit({ auth: token });
+
+    // Get base ref
+    const baseRef = await octo.rest.git.getRef({ owner, repo, ref: `heads/${base}` });
+    const baseSha = baseRef.data.object.sha;
+    const branch = `submit/${id}`;
+
+    // Create branch
+    await octo.rest.git.createRef({ owner, repo, ref: `refs/heads/${branch}`, sha: baseSha });
+
+    // Blobs
+    const blobs: { path: string; sha: string; mode: "100644"; type: "blob" }[] = [];
+
+    if (fileBuf) {
+      const fileSha = (await octo.rest.git.createBlob({
+        owner, repo, content: fileBuf.toString("base64"), encoding: "base64"
+      })).data.sha;
+      const ext = "." + (fileName.split(".").pop() || "pdf").toLowerCase();
+      const fname = `${id}${ext}`;
+      entry.file = `/files/${fname}`;
+      blobs.push({ path: `files/${fname}`, sha: fileSha, mode: "100644", type: "blob" });
+    }
+
+    const qaSha = (await octo.rest.git.createBlob({
+      owner, repo, content: Buffer.from(JSON.stringify(entry, null, 2)).toString("base64"),
+      encoding: "base64"
+    })).data.sha;
+    blobs.push({ path: `qa/${id}.json`, sha: qaSha, mode: "100644", type: "blob" });
+
+    // Tree
+    const tree = (await octo.rest.git.createTree({
+      owner, repo, base_tree: baseSha, tree: blobs
+    })).data;
+
+    // Commit
+    const commit = (await octo.rest.git.createCommit({
+      owner, repo, message: `chore(qa): ${question} (${date})`, tree: tree.sha, parents: [baseSha]
+    })).data;
+
+    await octo.rest.git.updateRef({ owner, repo, ref: `heads/${branch}`, sha: commit.sha, force: true });
+
+    // PR
+    const pr = (await octo.rest.pulls.create({
+      owner, repo, head: branch, base, title: `chore(qa): ${question}`,
+      body: `Auto-submitted from Trainer Form.\n\nTags: ${tags.join(", ") || "—"}`
+    })).data;
+
+    return json(res, { ok: true, prUrl: pr.html_url, id });
+  } catch (e: any) {
+    return json(res, { error: e?.message || "Server error" }, 500);
+  }
+}

--- a/site/package.json
+++ b/site/package.json
@@ -16,7 +16,9 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.0",
-    "d3": "^7.9.0"
+    "d3": "^7.9.0",
+    "octokit": "^4.0.0",
+    "busboy": "^1.6.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/site/src/App.jsx
+++ b/site/src/App.jsx
@@ -4,6 +4,7 @@ import Bibliography from './pages/Bibliography.jsx';
 import Compare from './pages/Compare.jsx';
 import About from './pages/About.jsx';
 import Graph from './pages/Graph.jsx';
+import Trainer from './pages/Trainer.jsx';
 
 export default function App() {
   return (
@@ -14,6 +15,7 @@ export default function App() {
         <NavLink to="/bibliography" className={({isActive}) => isActive ? 'active' : ''}>Bibliography</NavLink>{' | '}
         <NavLink to="/compare" className={({isActive}) => isActive ? 'active' : ''}>Compare</NavLink>{' | '}
         <NavLink to="/graph" className={({isActive}) => isActive ? 'active' : ''}>Graph</NavLink>{' | '}
+        <NavLink to="/trainer" className={({isActive}) => isActive ? 'active' : ''}>Trainer</NavLink>{' | '}
         <NavLink to="/about" className={({isActive}) => isActive ? 'active' : ''}>About</NavLink>
       </nav>
 
@@ -22,6 +24,7 @@ export default function App() {
         <Route path="/bibliography" element={<Bibliography />} />
         <Route path="/compare" element={<Compare />} />
         <Route path="/graph" element={<Graph />} />
+        <Route path="/trainer" element={<Trainer />} />
         <Route path="/about" element={<About />} />
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/site/src/pages/Trainer.jsx
+++ b/site/src/pages/Trainer.jsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+
+const SEED = [
+  "How does assemblage theory differ from structuralism?",
+  "What pedagogical move does Chapter 1 of ATM make?",
+  "How do you contrast your reading of affect with Massumi’s?"
+];
+
+export default function Trainer() {
+  const [q, setQ] = useState(SEED[0]);
+  const [answer, setAnswer] = useState("");
+  const [transcript, setTranscript] = useState("");
+  const [tags, setTags] = useState("assemblage, pedagogy");
+
+  async function onSubmit(e) {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const r = await fetch("/api/forms/submit-qa", {
+      method: "POST",
+      body: fd,
+      headers: { "X-Requested-With": "trainer-form" }
+    });
+    const j = await r.json();
+    if (!r.ok) return alert(j.error || "Submit failed");
+    alert(`Submitted! PR: ${j.prUrl}`);
+    e.currentTarget.reset();
+  }
+
+  return (
+    <main style={{maxWidth:680, margin:"40px auto", padding:"0 16px"}}>
+      <h1>Ian Trainer</h1>
+      <p>Answer any prompt below. You can type, paste a transcript, or attach a short PDF.</p>
+
+      <form onSubmit={onSubmit} encType="multipart/form-data">
+        <label>Question</label>
+        <select name="question" value={q} onChange={e=>setQ(e.target.value)}>
+          {SEED.map(s => <option key={s} value={s}>{s}</option>)}
+        </select>
+
+        <label style={{marginTop:12}}>Answer (text, optional if transcript or file provided)</label>
+        <textarea name="answer" rows={6} value={answer} onChange={e=>setAnswer(e.target.value)} />
+
+        <label style={{marginTop:12}}>Transcript (optional)</label>
+        <textarea name="transcript" rows={4} value={transcript} onChange={e=>setTranscript(e.target.value)} />
+
+        <label style={{marginTop:12}}>Attach PDF / .txt / .md (optional)</label>
+        <input type="file" name="file" accept=".pdf,.txt,.md" />
+
+        <label style={{marginTop:12}}>Tags (comma-separated)</label>
+        <input name="tags" value={tags} onChange={e=>setTags(e.target.value)} />
+
+        {/* Optional: hCaptcha widget */}
+        {/* <div className="h-captcha" data-sitekey={import.meta.env.VITE_HCAPTCHA_SITEKEY}></div> */}
+
+        <button type="submit" style={{marginTop:16}}>Submit to Vault</button>
+      </form>
+
+      <details style={{marginTop:20}}>
+        <summary>How it works</summary>
+        <ol>
+          <li>Your submission becomes a Pull Request in the Vault data repo.</li>
+          <li>On merge, the Q&A feed updates and the AI can cite it.</li>
+        </ol>
+      </details>
+    </main>
+  );
+}

--- a/site/vite.config.js
+++ b/site/vite.config.js
@@ -2,6 +2,9 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Summary
- add Trainer page for submitting Q&A entries
- add serverless form endpoint that opens PRs in data repo
- wire trainer route and fix Vite config

## Testing
- `yarn add octokit busboy` *(fails: tunneling socket could not be established, statusCode=403)*
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3dbb19bf4832b94a5ae964818a828