### PR TITLE
feat: add chip-style filters to graph

### DIFF
--- a/site/public/data/concepts.json
+++ b/site/public/data/concepts.json
@@ -1,0 +1,7 @@
+[
+  "assemblage",
+  "schizoanalysis",
+  "affect",
+  "war-machine",
+  "deterritorialization"
+]

--- a/site/public/data/scholars.json
+++ b/site/public/data/scholars.json
@@ -1,0 +1,4 @@
+[
+  { "id": "0000-0002-1825-0097", "name": "Sample Scholar A" },
+  { "id": "0000-0001-2345-6789", "name": "Sample Scholar B" }
+]

--- a/site/src/components/ChipSelect.tsx
+++ b/site/src/components/ChipSelect.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useMemo, useState } from 'react';
+
+export type Option = { value: string; label: string };
+type Props = {
+  label: string;
+  options: Option[];
+  selected: string[];
+  onChange: (next: string[]) => void;
+  placeholder?: string;
+  maxHeight?: number;
+};
+
+export default function ChipSelect({
+  label, options, selected, onChange, placeholder = 'Type to filter…', maxHeight = 220
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [q, setQ] = useState('');
+
+  const filtered = useMemo(() => {
+    const s = q.trim().toLowerCase();
+    return s ? options.filter(o => o.label.toLowerCase().includes(s)) : options;
+  }, [q, options]);
+
+  const toggle = (v: string) => {
+    const has = selected.includes(v);
+    const next = has ? selected.filter(x => x !== v) : [...selected, v];
+    onChange(next);
+  };
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  return (
+    <div className="chipsel">
+      <label className="chipsel__label">{label}</label>
+      <div className="chipsel__ctrl" onClick={() => setOpen(v => !v)}>
+        <div className="chipsel__chips">
+          {selected.length === 0 && <span className="chipsel__placeholder">None</span>}
+          {selected.map(v => {
+            const lbl = options.find(o => o.value === v)?.label || v;
+            return (
+              <button
+                key={v}
+                type="button"
+                className="chipsel__chip chipsel__chip--selected"
+                onClick={(e) => { e.stopPropagation(); toggle(v); }}
+                aria-pressed="true"
+              >
+                {lbl} <span aria-hidden>×</span>
+              </button>
+            );
+          })}
+        </div>
+        <span className="chipsel__caret" aria-hidden>▾</span>
+      </div>
+
+      {open && (
+        <div className="chipsel__panel" role="listbox" style={{ maxHeight }}>
+          <input
+            className="chipsel__search"
+            placeholder={placeholder}
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            onClick={(e) => e.stopPropagation()}
+          />
+          <div className="chipsel__list">
+            {filtered.map(o => {
+              const active = selected.includes(o.value);
+              return (
+                <button
+                  key={o.value}
+                  type="button"
+                  role="option"
+                  aria-selected={active}
+                  className={`chipsel__option${active ? ' is-active' : ''}`}
+                  onClick={(e) => { e.stopPropagation(); toggle(o.value); }}
+                >
+                  {o.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/site/src/components/chipSelect.css
+++ b/site/src/components/chipSelect.css
@@ -1,0 +1,21 @@
+.chipsel { position: relative; display: inline-block; min-width: 280px; }
+.chipsel__label { display:block; font-weight:600; margin:8px 0 4px; }
+.chipsel__ctrl {
+  border:1px solid #ddd; border-radius:10px; padding:6px 34px 6px 8px; min-height:40px; cursor:pointer;
+  background:#fff; display:flex; align-items:center; position:relative;
+}
+.chipsel__caret { position:absolute; right:10px; opacity:.6; }
+.chipsel__chips { display:flex; gap:6px; flex-wrap:wrap; }
+.chipsel__placeholder { color:#777; }
+.chipsel__chip {
+  border:1px solid rgba(0,0,0,.08); border-radius:999px; padding:4px 8px; background:#f6f6f6; font-size:12px;
+}
+.chipsel__chip--selected { background:#f0e9d0; border-color:#e3d08a; }
+.chipsel__panel {
+  position:absolute; z-index:50; left:0; right:0; margin-top:6px; border:1px solid #ddd; border-radius:10px;
+  background:#fff; box-shadow:0 10px 24px rgba(0,0,0,.12); overflow:auto;
+}
+.chipsel__search { width:100%; padding:8px 10px; border:0; border-bottom:1px solid #eee; outline:none; }
+.chipsel__list { display:grid; grid-template-columns:1fr; max-height:inherit; overflow:auto; }
+.chipsel__option { text-align:left; padding:8px 10px; border:0; background:#fff; cursor:pointer; }
+.chipsel__option:hover, .chipsel__option.is-active { background:#fff6d9; }


### PR DESCRIPTION
## Summary
- introduce reusable ChipSelect component for multi-select chip dropdowns
- wire chip-based scholar and concept filters into Rhizome Graph, applying selections during graph construction
- seed sample scholar and concept data for development

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b443af387c832ba2d31f0aea16f1f3