### PR TITLE
feat: add graph compile flow and instructions

### DIFF
--- a/site/public/styles/graph.css
+++ b/site/public/styles/graph.css
@@ -1,0 +1,6 @@
+#graph-canvas {
+  min-height: 420px;
+  background: #fafafa;
+  border: 1px solid #eee;
+  border-radius: 8px;
+}

--- a/site/src/lib/biblio.ts
+++ b/site/src/lib/biblio.ts
@@ -1,0 +1,13 @@
+export type Work = {
+  id: string; title: string; year?: number;
+  authors: { orcid?: string; name: string }[];
+  concepts?: string[];
+};
+
+export async function fetchWorksByOrcids(orcids: string[]): Promise<Work[]> {
+  const base = import.meta.env.VITE_KNOW_API_BASE as string;
+  const url = `${base}/biblio/works?orcids=${encodeURIComponent(orcids.join(","))}`;
+  const r = await fetch(url);
+  if (r.ok) return r.json();
+  throw new Error(`Failed to fetch works (${r.status})`);
+}


### PR DESCRIPTION
## Summary
- add biblio client for fetching works by ORCID
- wire graph compile button to fetch, filter, and render results with friendly fallbacks
- document graph usage via instructions accordion and ensure canvas styling

## Testing
- `cd site && yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68b4b9548f3c832b85dd64ce38319a4f