### PR TITLE
Add collapsible instructions with inline Know helper

### DIFF
--- a/site/src/App.jsx
+++ b/site/src/App.jsx
@@ -5,6 +5,7 @@ import Compare from './pages/Compare.jsx';
 import About from './pages/About.jsx';
 import Graph from './pages/Graph.jsx';
 import Trainer from './pages/Trainer.jsx';
+import Instructions from './pages/Instructions.jsx';
 
 export default function App() {
   return (
@@ -26,6 +27,7 @@ export default function App() {
         <Route path="/graph" element={<Graph />} />
         <Route path="/trainer" element={<Trainer />} />
         <Route path="/about" element={<About />} />
+        <Route path="/instructions" element={<Instructions />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </div>

--- a/site/src/components/Accordion.tsx
+++ b/site/src/components/Accordion.tsx
@@ -1,0 +1,31 @@
+import { useState, ReactNode } from "react";
+
+type Item = { id: string; title: string; content: ReactNode; defaultOpen?: boolean };
+
+export default function Accordion({ items }: { items: Item[] }) {
+  return (
+    <div className="acc">
+      {items.map(it => <AccordionItem key={it.id} {...it} />)}
+    </div>
+  );
+}
+
+function AccordionItem({ id, title, content, defaultOpen }: Item) {
+  const [open, setOpen] = useState(!!defaultOpen);
+  return (
+    <section className={`acc__item${open ? " is-open" : ""}`} aria-labelledby={`acc-${id}-btn`}>
+      <button
+        id={`acc-${id}-btn`}
+        className="acc__btn"
+        aria-expanded={open}
+        onClick={() => setOpen(v => !v)}
+      >
+        <span>{title}</span>
+        <span className="acc__caret" aria-hidden>▾</span>
+      </button>
+      <div className="acc__panel" role="region">
+        {open && <div className="acc__inner">{content}</div>}
+      </div>
+    </section>
+  );
+}

--- a/site/src/components/AskKnowInline.tsx
+++ b/site/src/components/AskKnowInline.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import { KnowClient } from "@/lib/knowClient";
+
+type Props = {
+  seed: string;        // initial question
+  context?: string;    // short context injected to the prompt
+  buttonLabel?: string;
+};
+
+export default function AskKnowInline({ seed, context, buttonLabel="Ask Know" }: Props) {
+  const [q, setQ] = useState(seed);
+  const [a, setA] = useState<string>("");
+  const [busy, setBusy] = useState(false);
+  const client = new KnowClient(); // uses env
+
+  async function ask() {
+    const msg = context ? `${context}\n\nQ: ${q}` : q;
+    setBusy(true); setA("");
+    try {
+      const res = await client.query(msg);
+      if ("needsTool" in res && res.needsTool) {
+        setA(res.draft || "This action requires a tool. Please try a simpler question.");
+      } else {
+        setA(res.answer);
+      }
+    } catch (e: any) {
+      setA(e?.message || "Error contacting Know.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="askknow">
+      <div className="askknow__row">
+        <input
+          className="askknow__input"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Ask a question about this section…"
+        />
+        <button className="askknow__btn" onClick={ask} disabled={busy}>
+          {busy ? "Thinking…" : buttonLabel}
+        </button>
+      </div>
+      {a && <div className="askknow__answer">{a}</div>}
+    </div>
+  );
+}

--- a/site/src/components/accordion.css
+++ b/site/src/components/accordion.css
@@ -1,0 +1,11 @@
+.acc { border-top: 1px solid #e7e7e7; }
+.acc__item { border-bottom: 1px solid #e7e7e7; }
+.acc__btn {
+  width: 100%; text-align: left; background: #fff; border: 0; padding: 14px 12px;
+  display: flex; justify-content: space-between; align-items: center; font-weight: 700; cursor: pointer;
+}
+.acc__caret { transition: transform .2s ease; }
+.acc__item.is-open .acc__caret { transform: rotate(180deg); }
+.acc__panel { background: #fff; }
+.acc__inner { padding: 10px 12px 16px; }
+.highlight { color: #C7A43A; font-weight: 600; }

--- a/site/src/components/askKnowInline.css
+++ b/site/src/components/askKnowInline.css
@@ -1,0 +1,13 @@
+.askknow { margin-top: 10px; }
+.askknow__row { display: flex; gap: 8px; }
+.askknow__input {
+  flex: 1; padding: 8px 10px; border: 1px solid #ddd; border-radius: 8px;
+}
+.askknow__btn {
+  padding: 8px 12px; border: 0; border-radius: 8px; background: var(--brand-accent, #C7A43A);
+  color: #000; font-weight: 700; cursor: pointer;
+}
+.askknow__answer {
+  margin-top: 8px; padding: 10px 12px; border: 1px solid #eee; border-radius: 8px; background: #fafafa;
+  white-space: pre-wrap;
+}

--- a/site/src/pages/Graph.jsx
+++ b/site/src/pages/Graph.jsx
@@ -4,7 +4,7 @@ import ChipSelect from '@/components/ChipSelect';
 import ScholarsSelect from '@/components/ScholarsSelect';
 import '@/components/chipSelect.css';
 import { fetchWorksByOrcids } from '@/lib/biblio';
-import '/styles/graph.css';
+import '@/styles/graph.css';
 
 // ---------- helpers ----------
 const fmt = (x) => (x ?? '').toString();
@@ -472,6 +472,9 @@ export default function Graph() {
         <div style={{marginTop:12}}>
           <button className="btn primary" onClick={compileGraph} style={{fontWeight:700}}>Compile</button>
           <small style={{marginLeft:8, opacity:.7}}>Builds graph with all current selections</small>
+          <p style={{marginTop:8}}>
+            Need help? <a href="/instructions">Read the Instructions</a> or ask right there via Know.
+          </p>
         </div>
 
         <details style={{marginTop:'1em'}}>

--- a/site/src/pages/Instructions.jsx
+++ b/site/src/pages/Instructions.jsx
@@ -1,0 +1,90 @@
+import Accordion from "@/components/Accordion";
+import "@/components/accordion.css";
+import AskKnowInline from "@/components/AskKnowInline";
+import "@/components/askKnowInline.css";
+
+export default function Instructions() {
+  const items = [
+    {
+      id: "philosophy",
+      title: "Philosophical Orientation",
+      defaultOpen: true,
+      content: (
+        <>
+          <p>
+            This graph is not a family tree or a linear timeline. It is a <span className="highlight">rhizome</span>:
+            a network of connections without hierarchy. Each time you compile the graph, you generate a
+            <span className="highlight"> cartography</span> — a map of relations in motion.
+          </p>
+          <p>
+            Think of each node (scholar, work, concept) as a <span className="highlight">component of an assemblage</span>.
+            Edges trace intensities: how concepts like <span className="highlight">assemblage</span>, affect, or becoming circulate across texts.
+          </p>
+          <AskKnowInline
+            seed="Explain how a rhizome differs from a tree in this visualization."
+            context="You are the Know assistant for the Buchanan Vault. The user is reading the 'Philosophical Orientation' section of the Instructions page about the Rhizome Graph."
+          />
+        </>
+      )
+    },
+    {
+      id: "practical",
+      title: "Practical Steps",
+      content: (
+        <>
+          <ul>
+            <li><b>Select Scholars:</b> Use the dropdown to choose key figures.</li>
+            <li><b>Select Concepts:</b> Pick central Deleuzian terms (assemblage, affect, deterritorialization...).</li>
+            <li><b>Adjust Parameters:</b> Year range, frequency, highlight ORCID.</li>
+            <li><b>Compile:</b> Press <i>Compile</i> to generate the rhizome.</li>
+          </ul>
+          <AskKnowInline
+            seed="What settings should I try to see assemblage between 2000–2010?"
+            context="You are the Know assistant for the Buchanan Vault. The user is in the 'Practical Steps' section and wants parameter guidance."
+          />
+        </>
+      )
+    },
+    {
+      id: "reading",
+      title: "Reading the Graph",
+      content: (
+        <>
+          <p>
+            <b>Nodes:</b> 🟦 Scholar · ⚪ Work · 🟨 Concept<br/>
+            <b>Edges:</b> co-authorship, citation, or conceptual overlap.<br/>
+            <b>Clusters:</b> Intensities may indicate <span className="highlight">lines of flight</span>.
+          </p>
+          <AskKnowInline
+            seed="How do I interpret clusters of affect-related works?"
+            context="The user is studying 'Reading the Graph' and needs help interpreting clusters."
+          />
+        </>
+      )
+    },
+    {
+      id: "cartography",
+      title: "Using the Graph as Cartography",
+      content: (
+        <>
+          <ul>
+            <li>Vary filters — each selection produces a <span className="highlight">different rhizome</span>.</li>
+            <li>Look for <span className="highlight">connections, overlaps, divergences</span> rather than origins.</li>
+            <li>Pose new research questions (e.g., where does 'affect' drop out after 2015?).</li>
+          </ul>
+          <AskKnowInline
+            seed="Suggest three research questions to explore with the current graph."
+            context="User is in 'Cartography'; propose research questions grounded in Deleuzian method."
+          />
+        </>
+      )
+    }
+  ];
+
+  return (
+    <div className="page">
+      <h1>📖 Instructions: How to Use the Rhizome Graph</h1>
+      <Accordion items={items} />
+    </div>
+  );
+}

--- a/site/src/styles/graph.css
+++ b/site/src/styles/graph.css
@@ -1,0 +1,6 @@
+#graph-canvas {
+  min-height: 420px;
+  background: #fafafa;
+  border: 1px solid #eee;
+  border-radius: 8px;
+}


### PR DESCRIPTION
## Summary
- add Accordion and AskKnowInline components for collapsible instruction sections with inline AI helper
- build new Instructions page using accordion sections and Ask Know prompts
- link graph page to instructions and expose page in router

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b4bc7b7c9c832baa39b2f6ef8eb3a0