### PR TITLE
feat: add cartography seed example and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
     "octokit": "^4",
     "papaparse": "^5.5.3"
   },
+  "scripts": {
+    "test": "npm --prefix site test"
+  },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/site/package.json
+++ b/site/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "fuse.js": "^7.1.0",
@@ -29,6 +30,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
-    "vite": "^5.4.0"
+    "vite": "^5.4.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/site/src/pages/Cartography.tsx
+++ b/site/src/pages/Cartography.tsx
@@ -2,21 +2,28 @@ import React from "react";
 import CartographyAsk from "@/components/CartographyAsk";
 import { compileCartography } from "@/lib/cartography";
 import { renderForceGraph } from "@/lib/graphRender";
+import seedSpec from "@/tests/fixtures/spec.seed.json";
 import "@/styles/graph.css";
 
 export default function Cartography() {
   const [notice, setNotice] = React.useState("");
   const [graph, setGraph] = React.useState(null as any);
+  const [spec, setSpec] = React.useState<any>(null);
 
-  async function onSpec(spec:any) {
+  async function compileAndRender(s:any) {
     try {
       setNotice("Compiling…");
-      const gj = await compileCartography(spec);
+      const gj = await compileCartography(s);
       setNotice("");
       setGraph(gj);
     } catch (e:any) {
       setNotice(String(e));
     }
+  }
+
+  async function onSpec(s:any) {
+    setSpec(s);
+    await compileAndRender(s);
   }
 
   React.useEffect(() => {
@@ -30,6 +37,15 @@ export default function Cartography() {
       <h1>Scholarly Cartography</h1>
       <p>Describe what you want to map; the AI compiles a cartography and we render it as a graph.</p>
       <CartographyAsk onSpec={onSpec} />
+      <button
+        className="btn btn-secondary"
+        onClick={() => {
+          setSpec(seedSpec);
+          compileAndRender(seedSpec);
+        }}
+      >
+        Load Example
+      </button>
       {notice && <div className="note">{notice}</div>}
       <div id="graph-canvas" style={{minHeight:480, marginTop:12, border:"1px solid #eee", borderRadius:8}} />
       {graph && <RefsDrawer refs={graph.refs} />}

--- a/site/src/tests/cartography.spec.ts
+++ b/site/src/tests/cartography.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from "vitest";
+import { compileCartography } from "@/lib/cartography";
+
+vi.mock("@/lib/biblio", () => ({
+  fetchWorksByOrcids: vi.fn(async () => (await import("./fixtures/works.mock.json")).default)
+}));
+
+vi.mock("@/lib/names", () => ({
+  resolveName: vi.fn(async (orcid: string) =>
+    orcid === "0000-0002-1825-0097" ? "Ian Buchanan" :
+    orcid === "0000-0002-4384-3615" ? "Brian Massumi" : orcid)
+}));
+
+vi.mock("@/lib/crossref", () => ({
+  enrichWithCrossref: vi.fn(async (w: any) => w)
+}));
+
+describe("compileCartography()", () => {
+  it("compiles seed example into nodes/edges/refs", async () => {
+    const spec = (await import("./fixtures/spec.seed.json")).default;
+    const expected = (await import("./fixtures/graph.expected.json")).default;
+    const out = await compileCartography(spec);
+    expect(out).toEqual(expected);
+  });
+});

--- a/site/src/tests/fixtures/graph.expected.json
+++ b/site/src/tests/fixtures/graph.expected.json
@@ -1,0 +1,24 @@
+{
+  "nodes": [
+    { "id": "concept:assemblage", "type": "concept", "label": "assemblage", "code": "#ASS" },
+    { "id": "concept:affect", "type": "concept", "label": "affect", "code": "#AFF" },
+    { "id": "IB:put1", "type": "work", "label": "Assemblage and the Everyday", "year": 2015, "url": "https://doi.org/10.0000/assemblage-everyday", "code": "AA-15" },
+    { "id": "0000-0002-1825-0097", "type": "author", "label": "Ian Buchanan", "orcid": "0000-0002-1825-0097", "code": "IB" },
+    { "id": "BM:put2", "type": "work", "label": "Parables for the Virtual: Movement, Affect, Sensation", "year": 2002, "url": "https://doi.org/10.0000/parables-virtual", "code": "PF-02" },
+    { "id": "0000-0002-4384-3615", "type": "author", "label": "Brian Massumi", "orcid": "0000-0002-4384-3615", "code": "BM" }
+  ],
+  "edges": [
+    { "source": "0000-0002-1825-0097", "target": "IB:put1", "kind": "authored" },
+    { "source": "concept:assemblage", "target": "IB:put1", "kind": "concept" },
+    { "source": "0000-0002-4384-3615", "target": "BM:put2", "kind": "authored" },
+    { "source": "concept:affect", "target": "BM:put2", "kind": "concept" }
+  ],
+  "refs": {
+    "#ASS": [
+      { "title": "Assemblage and the Everyday", "url": "https://doi.org/10.0000/assemblage-everyday", "year": 2015 }
+    ],
+    "#AFF": [
+      { "title": "Parables for the Virtual: Movement, Affect, Sensation", "url": "https://doi.org/10.0000/parables-virtual", "year": 2002 }
+    ]
+  }
+}

--- a/site/src/tests/fixtures/spec.seed.json
+++ b/site/src/tests/fixtures/spec.seed.json
@@ -1,0 +1,8 @@
+{
+  "mode": "concept_comparison",
+  "concepts": ["assemblage", "affect"],
+  "scholars": ["0000-0002-1825-0097", "0000-0002-4384-3615"],
+  "years": { "min": 2000, "max": 2015 },
+  "minConceptFreq": 1,
+  "notes": "Compare assemblage vs affect across Buchanan & Massumi, 2000–2015"
+}

--- a/site/src/tests/fixtures/works.mock.json
+++ b/site/src/tests/fixtures/works.mock.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "IB:put1",
+    "title": "Assemblage and the Everyday",
+    "year": 2015,
+    "authors": [{ "orcid": "0000-0002-1825-0097", "name": "Ian Buchanan" }],
+    "concepts": [],
+    "url": "https://doi.org/10.0000/assemblage-everyday"
+  },
+  {
+    "id": "BM:put2",
+    "title": "Parables for the Virtual: Movement, Affect, Sensation",
+    "year": 2002,
+    "authors": [{ "orcid": "0000-0002-4384-3615", "name": "Brian Massumi" }],
+    "concepts": [],
+    "url": "https://doi.org/10.0000/parables-virtual"
+  }
+]


### PR DESCRIPTION
## Summary
- add seed spec & fixtures for example cartography
- provide unit test harness for compileCartography()
- allow loading the seed spec from /cartography page

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4dcbe2130832bb173530b457706d5