### PR TITLE
feat: add shared cartography guide

### DIFF
--- a/site/src/components/GuideAccordion.tsx
+++ b/site/src/components/GuideAccordion.tsx
@@ -1,0 +1,38 @@
+import { guide } from "@/content/cartographyGuide";
+import { KnowClient } from "@/lib/knowClient";
+import React from "react";
+
+function AskKnow({ prompt }: {prompt:string}) {
+  const client = new KnowClient();
+  return (
+    <button className="ask-know" onClick={async ()=>{
+      const res = await client.query(prompt);
+      const text = "needsTool" in res ? res.draft || "…" : res.answer || "…";
+      alert(text); // minimal: page already has the Know widget; this is a quick inline assist
+    }}>Ask Know</button>
+  );
+}
+
+export default function GuideAccordion({ mode = "compact" }:{ mode?: "compact" | "full" }) {
+  return (
+    <div className="guide-acc">
+      <details open>
+        <summary>Philosophical</summary>
+        <p>{guide.philosophical.trim()}</p>
+        {mode==="compact" && <AskKnow prompt="Explain rhizome vs tree in this graph." />}
+      </details>
+
+      <details open={mode==="full"}>
+        <summary>Practical</summary>
+        <div dangerouslySetInnerHTML={{__html: guide.practical.trim().replace(/\n/g,"<br/>")}} />
+        {mode==="compact" && <AskKnow prompt="What settings reveal assemblage best here?" />}
+      </details>
+
+      <details open={mode==="full"}>
+        <summary>Cartography</summary>
+        <div dangerouslySetInnerHTML={{__html: guide.cartography.trim().replace(/\n/g,"<br/>")}} />
+        {mode==="compact" && <AskKnow prompt="Help me read this cartography: what stands out?" />}
+      </details>
+    </div>
+  );
+}

--- a/site/src/content/cartographyGuide.ts
+++ b/site/src/content/cartographyGuide.ts
@@ -1,0 +1,27 @@
+export const guide = {
+  philosophical: `
+Think of each node (scholar, work, concept) as a **component of an assemblage**. 
+Edges are **intensities/relations**: how concepts like *assemblage*, *affect*, or *becoming* circulate across texts.
+This is a **rhizome**: not a tree with roots and branches, but a mesh of partial connections that can be cut, spliced, and rejoined.
+Use the map *cartographically*: to trace **lines of flight**, not to prove essences.
+`,
+
+  practical: `
+**Select Scholars** via ORCID or the dropdown.  
+**Select Concepts** (assemblage, affect, deterritorialization…).  
+**Adjust Parameters** (year range, concept frequency, highlight ORCID).  
+**Compile** to generate the graph. Click nodes to open DOI/publisher; open the “References by code” drawer to cite.
+`,
+
+  cartography: `
+**Reading the graph**  
+• **Authors** (blue), **Works** (gray), **Concepts** (gold).  
+• **Authored** edges connect author → work; **Concept** edges connect concept → work; **Co-author** and **Influence** edges appear in those modes.  
+• Codes like **IB-15** = initials + year; **#ASS** = concept tag (Assemblage).
+
+**Use as Cartography**  
+• Compare concepts by filtering edges to #ASS vs #AFF.  
+• Trace lineages by watching **influence** edges move forward in time.  
+• Find clusters: raise min concept freq to de-noise; co-work mode shows author clusters.
+`
+};

--- a/site/src/pages/Cartography.tsx
+++ b/site/src/pages/Cartography.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import CartographyAsk from "@/components/CartographyAsk";
+import GuideAccordion from "@/components/GuideAccordion";
 import { compileCartography } from "@/lib/cartography";
 import { renderForceGraph } from "@/lib/graphRender";
 import "@/styles/graph.css";
@@ -30,6 +31,7 @@ export default function Cartography() {
       <h1>Scholarly Cartography</h1>
       <p>Describe what you want to map; the AI compiles a cartography and we render it as a graph.</p>
       <CartographyAsk onSpec={onSpec} />
+      <GuideAccordion mode="compact" />
       {notice && <div className="note">{notice}</div>}
       <div id="graph-canvas" style={{minHeight:480, marginTop:12, border:"1px solid #eee", borderRadius:8}} />
       {graph && <RefsDrawer refs={graph.refs} />}

--- a/site/src/pages/Instructions.jsx
+++ b/site/src/pages/Instructions.jsx
@@ -1,90 +1,12 @@
-import Accordion from "@/components/Accordion";
-import "@/components/accordion.css";
-import AskKnowInline from "@/components/AskKnowInline";
-import "@/components/askKnowInline.css";
+import GuideAccordion from "@/components/GuideAccordion";
+import "@/styles/graph.css";
 
 export default function Instructions() {
-  const items = [
-    {
-      id: "philosophy",
-      title: "Philosophical Orientation",
-      defaultOpen: true,
-      content: (
-        <>
-          <p>
-            This graph is not a family tree or a linear timeline. It is a <span className="highlight">rhizome</span>:
-            a network of connections without hierarchy. Each time you compile the graph, you generate a
-            <span className="highlight"> cartography</span> — a map of relations in motion.
-          </p>
-          <p>
-            Think of each node (scholar, work, concept) as a <span className="highlight">component of an assemblage</span>.
-            Edges trace intensities: how concepts like <span className="highlight">assemblage</span>, affect, or becoming circulate across texts.
-          </p>
-          <AskKnowInline
-            seed="Explain how a rhizome differs from a tree in this visualization."
-            context="You are the Know assistant for the Buchanan Vault. The user is reading the 'Philosophical Orientation' section of the Instructions page about the Rhizome Graph."
-          />
-        </>
-      )
-    },
-    {
-      id: "practical",
-      title: "Practical Steps",
-      content: (
-        <>
-          <ul>
-            <li><b>Select Scholars:</b> Use the dropdown to choose key figures.</li>
-            <li><b>Select Concepts:</b> Pick central Deleuzian terms (assemblage, affect, deterritorialization...).</li>
-            <li><b>Adjust Parameters:</b> Year range, frequency, highlight ORCID.</li>
-            <li><b>Compile:</b> Press <i>Compile</i> to generate the rhizome.</li>
-          </ul>
-          <AskKnowInline
-            seed="What settings should I try to see assemblage between 2000–2010?"
-            context="You are the Know assistant for the Buchanan Vault. The user is in the 'Practical Steps' section and wants parameter guidance."
-          />
-        </>
-      )
-    },
-    {
-      id: "reading",
-      title: "Reading the Graph",
-      content: (
-        <>
-          <p>
-            <b>Nodes:</b> 🟦 Scholar · ⚪ Work · 🟨 Concept<br/>
-            <b>Edges:</b> co-authorship, citation, or conceptual overlap.<br/>
-            <b>Clusters:</b> Intensities may indicate <span className="highlight">lines of flight</span>.
-          </p>
-          <AskKnowInline
-            seed="How do I interpret clusters of affect-related works?"
-            context="The user is studying 'Reading the Graph' and needs help interpreting clusters."
-          />
-        </>
-      )
-    },
-    {
-      id: "cartography",
-      title: "Using the Graph as Cartography",
-      content: (
-        <>
-          <ul>
-            <li>Vary filters — each selection produces a <span className="highlight">different rhizome</span>.</li>
-            <li>Look for <span className="highlight">connections, overlaps, divergences</span> rather than origins.</li>
-            <li>Pose new research questions (e.g., where does 'affect' drop out after 2015?).</li>
-          </ul>
-          <AskKnowInline
-            seed="Suggest three research questions to explore with the current graph."
-            context="User is in 'Cartography'; propose research questions grounded in Deleuzian method."
-          />
-        </>
-      )
-    }
-  ];
-
   return (
     <div className="page">
-      <h1>📖 Instructions: How to Use the Rhizome Graph</h1>
-      <Accordion items={items} />
+      <h1>Instructions</h1>
+      <p>How to use the Buchanan Vault and Scholarly Cartography.</p>
+      <GuideAccordion mode="full" />
     </div>
   );
 }

--- a/site/src/styles/graph.css
+++ b/site/src/styles/graph.css
@@ -11,3 +11,8 @@
 .askrow input { flex:1; padding:10px; border:1px solid #ddd; border-radius:8px; }
 .askrow button { padding:10px 12px; border-radius:8px; border:0; background:var(--brand-accent,#C7A43A); color:#000; font-weight:700; }
 .note { margin-top:8px; color:#666; }
+
+.guide-acc details { margin: 8px 0; }
+.guide-acc summary { font-weight: 700; cursor: pointer; }
+.ask-know { margin-top: 6px; padding:6px 10px; border:0; border-radius:8px;
+  background: var(--brand-accent, #C7A43A); color:#000; font-weight:700; }


### PR DESCRIPTION
## Summary
- centralize cartography instructions in a single content module
- add reusable `GuideAccordion` with optional Ask Know hooks
- show compact guide on Cartography page and full guide on Instructions page

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b4dd678a1c832bb8e316ac96ea0440