### PR TITLE
docs: add standalone Scholarly Cartography guide

### DIFF
--- a/site/public/guide.css
+++ b/site/public/guide.css
@@ -1,0 +1,10 @@
+:root{ --accent: var(--brand-accent, #C7A43A); }
+body{ margin:0; font:16px/1.5 system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; color:#111; }
+.wrapper{ max-width:880px; margin:48px auto; padding:0 16px; }
+h1{ font-size:28px; margin:0 0 8px; }
+.subtitle{ color:#555; margin:0 0 24px; }
+summary{ font-weight:700; cursor:pointer; }
+details{ border:1px solid #eee; border-radius:10px; padding:10px 14px; margin:12px 0; background:#fff; }
+.callout{ background:#111; color:#f6f6f6; border-radius:12px; padding:14px 16px; margin:12px 0; }
+.btn{ display:inline-block; padding:10px 12px; border-radius:8px; border:0; background:var(--accent); color:#000; font-weight:700; text-decoration:none; }
+.small{ font-size:13px; color:#666; }

--- a/site/public/guide.html
+++ b/site/public/guide.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>Scholarly Cartography — Guide</title>
+<link rel="stylesheet" href="/guide.css"/>
+<body>
+  <div class="wrapper">
+    <h1>Scholarly Cartography — Guide</h1>
+    <p class="subtitle">How to read and use the Buchanan Vault’s cartographic maps.</p>
+
+    <details open>
+      <summary>Philosophical</summary>
+      <div class="callout">
+        Think of each node (scholar, work, concept) as a <b>component of an assemblage</b>.
+        Edges trace <b>intensities</b>: how concepts like <i>assemblage</i>, <i>affect</i>, or 
+        <i>becoming</i> circulate across texts. This is a <b>rhizome</b>: not a tree with roots 
+        and branches, but a mesh of partial connections that can be cut, spliced, and rejoined.
+        Use the map <b>cartographically</b>: to trace <i>lines of flight</i>, not to prove essences.
+      </div>
+      <p class="small">Tip: open the site’s “Know” bubble and ask: “Explain rhizome vs tree in this map.”</p>
+    </details>
+
+    <details open>
+      <summary>Practical Steps</summary>
+      <ul>
+        <li><b>Select Scholars</b> (ORCID or dropdown).</li>
+        <li><b>Select Concepts</b> (assemblage, affect, deterritorialization…).</li>
+        <li><b>Adjust Parameters</b> (year range, concept frequency, highlight ORCID).</li>
+        <li><b>Compile</b> to generate the graph; click nodes to open DOI/publisher.</li>
+      </ul>
+      <p class="small">Need help composing a query? Ask the Know bubble: “What settings show assemblage best?”</p>
+    </details>
+
+    <details open>
+      <summary>Reading the Graph</summary>
+      <ul>
+        <li><b>Authors</b> (blue), <b>Works</b> (gray), <b>Concepts</b> (gold).</li>
+        <li><b>Authored</b> edges connect author→work; <b>Concept</b> edges connect concept→work;
+            <b>Co-author</b> and <b>Influence</b> edges appear in those modes.</li>
+        <li>Codes like <b>IB-15</b> = initials + year; <b>#ASS</b> = concept tag (Assemblage).</li>
+      </ul>
+      <p class="small">Use “References by code” under the graph to copy citations quickly.</p>
+    </details>
+
+    <p>
+      <a class="btn" href="/cartography">Open Cartography</a>
+      <span class="small"> &nbsp;|&nbsp; This guide lives at <code>/guide.html</code>.</span>
+    </p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add static Scholarly Cartography guide at `/guide.html`
- style guide with brand-accent aware CSS

## Testing
- `npm test` *(fails: vitest not found; package install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e0caa680832bbe9a164f03b2a94a