### PR TITLE
feat: NodeInfo pinning, caching, and trainer export

### DIFF
--- a/site/src/components/NodeInfo.tsx
+++ b/site/src/components/NodeInfo.tsx
@@ -1,92 +1,183 @@
 import React from "react";
 import { KnowClient } from "@/lib/knowClient";
 
-type Node = { id:string; type:"author"|"work"|"concept"; label:string; code?:string; year?:number; url?:string; orcid?:string };
-type Ref = { title:string; url?:string; doi?:string; year?:number };
+type Node = {
+  id: string;
+  type: "author" | "work" | "concept";
+  label: string;
+  code?: string;
+  year?: number;
+  url?: string;
+  orcid?: string;
+};
+type Ref = { title: string; url?: string; doi?: string; year?: number };
+
+const sessionCache = new Map<string, string>();
 
 export default function NodeInfo({
-  node,
+  node: nodeProp,
   refsByCode,
-  onClose
-}:{
+  onClose,
+}: {
   node: Node;
   refsByCode: Record<string, Ref[]>;
-  onClose: ()=>void;
+  onClose: () => void;
 }) {
-  const [busy,setBusy] = React.useState(false);
-  const [answer,setAnswer] = React.useState<string>("");
-  const [citations,setCitations] = React.useState<{title:string;url?:string}[]>([]);
+  const [busy, setBusy] = React.useState(false);
+  const [answer, setAnswer] = React.useState<string>("");
+  const [citations, setCitations] = React.useState<{
+    title: string;
+    url?: string;
+  }[]>([]);
+  const [pinned, setPinned] = React.useState(false);
+  const [currentNode, setCurrentNode] = React.useState(nodeProp);
   const client = new KnowClient();
+
+  React.useEffect(() => {
+    if (!pinned) setCurrentNode(nodeProp);
+  }, [nodeProp, pinned]);
+
+  const cacheKey = `${currentNode.type}:${currentNode.id}`;
+
+  React.useEffect(() => {
+    setCitations([]);
+    if (sessionCache.has(cacheKey)) {
+      setAnswer(sessionCache.get(cacheKey)!);
+    } else {
+      setAnswer("");
+    }
+  }, [cacheKey]);
 
   // build a tiny context from our graph
   function buildContext() {
-    const lines:string[] = [];
-    if (node.type === "concept") {
-      const code = node.code || "";
+    const lines: string[] = [];
+    if (currentNode.type === "concept") {
+      const code = currentNode.code || "";
       const refs = refsByCode[code] || [];
       if (refs.length) {
         lines.push("Relevant works:");
-        for (const r of refs.slice(0,6)) lines.push(`- ${r.title}${r.year?` (${r.year})`: ""}${r.doi?` doi:${r.doi}`:""}`);
+        for (const r of refs.slice(0, 6))
+          lines.push(
+            `- ${r.title}${r.year ? ` (${r.year})` : ""}${r.doi ? ` doi:${r.doi}` : ""}`
+          );
       }
     }
-    if (node.type === "work" && node.year) lines.push(`Work year: ${node.year}`);
-    if (node.type === "author" && node.orcid) lines.push(`Author ORCID: ${node.orcid}`);
+    if (currentNode.type === "work" && currentNode.year)
+      lines.push(`Work year: ${currentNode.year}`);
+    if (currentNode.type === "author" && currentNode.orcid)
+      lines.push(`Author ORCID: ${currentNode.orcid}`);
     return lines.join("\n");
   }
 
   async function ask() {
+    if (sessionCache.has(cacheKey)) {
+      setAnswer(sessionCache.get(cacheKey)!);
+      return;
+    }
     setBusy(true);
     try {
       const prompt = [
-        `Explain "${node.label}" (${node.type}).`,
+        `Explain "${currentNode.label}" (${currentNode.type}).`,
         `Relate it to Deleuzian usage and Buchanan’s scholarship when applicable.`,
         `Be concise (120–180 words) and define jargon.`,
         `Use the provided "Relevant works" when present and prefer those for citations.`,
-        buildContext()
+        buildContext(),
       ].join("\n");
       const res = await client.query(prompt);
-      if ("needsTool" in res) setAnswer(res.draft || ""); else setAnswer(res.answer || "");
-      setCitations(
-        (res.citations || []).slice(0,6)
-      );
-    } catch (e:any) {
+      const ans =
+        "needsTool" in res ? res.draft || "" : (res as any).answer || "";
+      setAnswer(ans);
+      sessionCache.set(cacheKey, ans);
+      setCitations((res.citations || []).slice(0, 6));
+    } catch (e: any) {
       setAnswer(`(Error) ${e?.message || String(e)}`);
     } finally {
       setBusy(false);
     }
   }
 
-  const localRefs = node.type==="concept" ? (refsByCode[node.code || ""] || []) : [];
+  const localRefs =
+    currentNode.type === "concept"
+      ? refsByCode[currentNode.code || ""] || []
+      : [];
 
   return (
     <div className="nodeinfo">
       <div className="ni-head">
-        <b>{node.label}</b> <small style={{opacity:.8}}>({node.type})</small>
-        <button className="ni-x" onClick={onClose}>×</button>
+        <b>{currentNode.label}</b>{" "}
+        <small style={{ opacity: 0.8 }}>({currentNode.type})</small>
+        <div>
+          <button className="ni-pin" onClick={() => setPinned(!pinned)}>
+            {pinned ? "📌" : "📍"}
+          </button>
+          <button
+            className="ni-x"
+            onClick={() => {
+              setPinned(false);
+              onClose();
+            }}
+          >
+            ×
+          </button>
+        </div>
       </div>
 
-      {node.url && <p><a href={node.url} target="_blank" rel="noreferrer">Open source</a></p>}
+      {currentNode.url && (
+        <p>
+          <a href={currentNode.url} target="_blank" rel="noreferrer">
+            Open source
+          </a>
+        </p>
+      )}
 
       <button className="ni-ask" disabled={busy} onClick={ask}>
         {busy ? "Asking…" : "Ask AI about this"}
       </button>
 
-      {answer && <div className="ni-answer">{answer}</div>}
+      {answer && (
+        <>
+          <div className="ni-answer">{answer}</div>
+          <button
+            className="ni-trainer"
+            onClick={() => {
+              const draft = {
+                q: `Explain ${currentNode.label}`,
+                a: answer,
+                tags: [currentNode.type, currentNode.label],
+              };
+              sessionStorage.setItem(
+                "trainer-draft",
+                JSON.stringify(draft)
+              );
+              window.location.href = "/trainer";
+            }}
+          >
+            Save to Trainer
+          </button>
+        </>
+      )}
 
-      {(localRefs.length>0 || citations.length>0) && (
+      {(localRefs.length > 0 || citations.length > 0) && (
         <div className="ni-refs">
           <div className="ni-sub">Citations</div>
           <ul>
-            {localRefs.map((r,i)=>(
+            {localRefs.map((r, i) => (
               <li key={`lr-${i}`}>
-                <a href={r.url || (r.doi ? `https://doi.org/${r.doi}` : "#")} target="_blank" rel="noreferrer">
-                  {r.title}{r.year?` (${r.year})`:""}
+                <a
+                  href={r.url || (r.doi ? `https://doi.org/${r.doi}` : "#")}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {r.title}
+                  {r.year ? ` (${r.year})` : ""}
                 </a>
               </li>
             ))}
-            {citations.map((c,i)=>(
+            {citations.map((c, i) => (
               <li key={`kc-${i}`}>
-                <a href={c.url || "#"} target="_blank" rel="noreferrer">{c.title}</a>
+                <a href={c.url || "#"} target="_blank" rel="noreferrer">
+                  {c.title}
+                </a>
               </li>
             ))}
           </ul>

--- a/site/src/styles/graph.css
+++ b/site/src/styles/graph.css
@@ -15,9 +15,11 @@
   background:#fff; border:1px solid #eee; border-radius:12px; box-shadow:0 12px 28px rgba(0,0,0,.12);
   padding:12px; z-index:1000; }
 .ni-head{ display:flex; align-items:center; justify-content:space-between; margin-bottom:6px; }
+.ni-pin{ border:0; background:none; font-size:16px; margin-right:6px; cursor:pointer; }
 .ni-x{ border:0; background:none; font-size:18px; cursor:pointer; }
 .ni-ask{ padding:8px 10px; border:0; border-radius:8px; background:var(--brand-accent,#C7A43A); color:#000; font-weight:700; }
 .ni-answer{ margin-top:8px; padding:8px 10px; background:#fafafa; border-radius:8px; }
+.ni-trainer{ margin-top:6px; padding:6px 10px; border:0; border-radius:6px; background:#444; color:#fff; font-size:13px; cursor:pointer; }
 .ni-refs{ margin-top:10px; }
 .ni-refs .ni-sub{ font-weight:700; margin-bottom:4px; }
 .ni-refs ul{ margin:0; padding-left:18px; }


### PR DESCRIPTION
## Summary
- add pin toggle on NodeInfo, cache answers per node, and export answers to Trainer
- style pin and Trainer buttons
- prefill Trainer form from saved draft in sessionStorage

## Testing
- `yarn test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e49d3670832ba15c25647b3c887a