### PR TITLE
feat: load scholar groups on cartography page

### DIFF
--- a/site/src/lib/knowClient.ts
+++ b/site/src/lib/knowClient.ts
@@ -35,4 +35,17 @@ export class KnowClient {
     if (!r.ok) throw new Error(`query(): ${r.status}`);
     return r.json();
   }
+
+  async groups(): Promise<{ groups: Record<string, { slug: string; description?: string; members: string[] }> }> {
+    const r = await fetch(`${this.base}/catalog/groups`);
+    if (!r.ok) throw new Error(`groups(): ${r.status}`);
+    return r.json();
+  }
+
+  async groupDetail(name: string): Promise<{ group: string; meta?: any; scholars: any[] }> {
+    const enc = encodeURIComponent(name);
+    const r = await fetch(`${this.base}/catalog/groups/${enc}`);
+    if (!r.ok) throw new Error(`groupDetail(${name}): ${r.status}`);
+    return r.json();
+  }
 }

--- a/site/src/pages/Cartography.tsx
+++ b/site/src/pages/Cartography.tsx
@@ -5,12 +5,53 @@ import { compileCartography } from "@/lib/cartography";
 import { renderForceGraph } from "@/lib/graphRender";
 import seedSpec from "@/tests/fixtures/spec.seed.json";
 import "@/styles/graph.css";
+import { KnowClient } from "@/lib/knowClient";
+
+const client = new KnowClient();
 
 export default function Cartography() {
   const [notice, setNotice] = React.useState("");
   const [graph, setGraph] = React.useState(null as any);
   const [spec, setSpec] = React.useState<any>(null);
   const [selected, setSelected] = React.useState<any>(null);
+  const [groups, setGroups] = React.useState<any[]>([]);
+  const [groupName, setGroupName] = React.useState("");
+  const [scholars, setScholars] = React.useState<string[]>([]);
+  const [allScholars, setAllScholars] = React.useState<string[]>([]);
+
+  React.useEffect(() => {
+    let alive = true;
+    client.groups()
+      .then(({ groups }) => {
+        if (!alive) return;
+        const list = Object.entries(groups).map(([name, meta]: any) => ({
+          name,
+          members: meta.members || [],
+          slug: meta.slug,
+          description: meta.description || ""
+        }));
+        setGroups(list);
+      })
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  async function loadGroup(name: string) {
+    try {
+      const { scholars: full } = await client.groupDetail(name);
+      const names = full.map((s: any) => s.name);
+      setScholars(names);
+      setAllScholars(prev => {
+        const set = new Set([...(prev || []), ...names]);
+        return Array.from(set);
+      });
+    } catch (e) {
+      console.error("loadGroup:", e);
+      alert(`Failed to load group: ${name}`);
+    }
+  }
 
   async function compileAndRender(s:any) {
     try {
@@ -24,8 +65,9 @@ export default function Cartography() {
   }
 
   async function onSpec(s:any) {
-    setSpec(s);
-    await compileAndRender(s);
+    const specWithScholars = scholars.length ? { ...s, scholars } : s;
+    setSpec(specWithScholars);
+    await compileAndRender(specWithScholars);
   }
 
   React.useEffect(() => {
@@ -40,6 +82,36 @@ export default function Cartography() {
     <div className="page">
       <h1>Scholarly Cartography</h1>
       <p>Describe what you want to map; the AI compiles a cartography and we render it as a graph.</p>
+      <div style={{ marginBottom: 8 }}>
+        <label htmlFor="group">Load Group:&nbsp;</label>
+        <select id="group" value={groupName} onChange={(e) => setGroupName(e.target.value)}>
+          <option value="">— Select a group —</option>
+          {groups.map(g => (
+            <option key={g.name} value={g.name}>{g.name}</option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={() => groupName && loadGroup(groupName)}
+          disabled={!groupName}
+          style={{ marginLeft: 8 }}
+        >
+          Load
+        </button>
+      </div>
+      <div style={{ marginBottom: 8 }}>
+        <label htmlFor="scholars">Scholars:&nbsp;</label>
+        <select
+          id="scholars"
+          multiple
+          value={scholars}
+          onChange={(e) => setScholars(Array.from(e.target.selectedOptions).map(o => o.value))}
+        >
+          {allScholars.map(name => (
+            <option key={name} value={name}>{name}</option>
+          ))}
+        </select>
+      </div>
       <CartographyAsk onSpec={onSpec} />
       <button
         className="btn btn-secondary"


### PR DESCRIPTION
## Summary
- add catalog group methods to KnowClient
- allow Cartography page to load groups and populate scholar selection

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fcb2b5ac832b9fe40026ee9f93b5