### PR TITLE
CWO-FE-VaultPedia-IB-A01 — Add IanBuchanan page & route

### DIFF
--- a/site/src/App.jsx
+++ b/site/src/App.jsx
@@ -19,6 +19,7 @@ export default function App() {
         <NavLink to="/cartography" className={({isActive}) => isActive ? 'active' : ''}>Cartography</NavLink>{' | '}
         <NavLink to="/instructions" className={({isActive}) => isActive ? 'active' : ''}>Instructions</NavLink>{' | '}
         <NavLink to="/trainer" className={({isActive}) => isActive ? 'active' : ''}>Trainer</NavLink>{' | '}
+        <NavLink to="/vaultpedia/ian-buchanan" className={({isActive}) => isActive ? 'active' : ''}>VaultPedia: Ian Buchanan</NavLink>{' | '}
         <NavLink to="/about" className={({isActive}) => isActive ? 'active' : ''}>About</NavLink>
       </nav>
 


### PR DESCRIPTION
## Summary
- add navigation link to Ian Buchanan's VaultPedia entry
- confirm Vite alias and SPA rewrite setup

## Testing
- `npm test` *(fails: vitest not found)*
- `npm --prefix site install` *(fails: 403 Forbidden for vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68b503ac29fc832bac654ceabd6e94e0