### PR TITLE
feat: SEO meta and sitemap for VaultPedia

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -16,6 +16,7 @@
     "papaparse": "^5.5.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-helmet-async": "^1.3.0",
     "react-router-dom": "^6.26.0",
     "d3": "^7.9.0",
     "octokit": "^4.0.0",

--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: /sitemap.xml

--- a/site/public/sitemap.xml
+++ b/site/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>/</loc></url>
+  <url><loc>/vaultpedia/ian-buchanan</loc></url>
+  <url><loc>/cartography</loc></url>
+  <url><loc>/bibliography</loc></url>
+  <url><loc>/reading-list</loc></url>
+</urlset>

--- a/site/src/main.jsx
+++ b/site/src/main.jsx
@@ -1,14 +1,17 @@
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
+import { HelmetProvider } from 'react-helmet-async'
 import App from './App.jsx'
 import './styles/global.css'
 import "@/widgets/knowWidget.css";
 import { KnowWidget } from "@/widgets/KnowWidget";
 
 createRoot(document.getElementById('root')).render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>
+  <HelmetProvider>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </HelmetProvider>
 );
 
 // --- Know widget mount (auto-added by CWO) ---

--- a/site/src/pages/Trainer.jsx
+++ b/site/src/pages/Trainer.jsx
@@ -106,7 +106,9 @@ export default function Trainer() {
         }
         if (a) setAnswer(a);
         if (t) setTags(Array.isArray(t) ? t.join(", ") : t);
-      } catch {}
+      } catch {
+        /* noop */
+      }
       sessionStorage.removeItem("trainer-draft");
     }
   }, []);

--- a/site/src/pages/vaultpedia/IanBuchanan.jsx
+++ b/site/src/pages/vaultpedia/IanBuchanan.jsx
@@ -6,6 +6,7 @@
 // - Drop-in ready for Vite/React. Ensure your router points this path to <IanBuchanan />.
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Helmet } from "react-helmet-async";
 import "./IanBuchanan.css";
 
 function askKnow(msg) {
@@ -36,7 +37,8 @@ const sections = [
   { id: "reception-influence", label: "4. Reception & Influence" },
   { id: "conceptual-contributions", label: "5. Conceptual Contributions" },
   { id: "selected-talks", label: "6. Selected Talks & YouTube" },
-  { id: "references", label: "7. References" },
+  { id: "faq", label: "7. FAQ" },
+  { id: "references", label: "8. References" },
 ];
 
 function useActiveSection(sectionIds) {
@@ -116,22 +118,90 @@ export default function IanBuchanan() {
     { id: "6P4DT1cJkCE", title: "Assemblage Theory as the Engine that Drives Schizoanalysis (Buchanan channel)" },
   ];
 
+  const faq = [
+    {
+      q: "What is Ian Buchanan known for?",
+      a: "He is a scholar of Deleuze and Guattari, noted for work on assemblage theory and schizoanalysis.",
+    },
+    {
+      q: "Where does he teach?",
+      a: "Buchanan is a professor in the School of Humanities and Social Inquiry at the University of Wollongong.",
+    },
+  ];
+
+  const personJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: "Ian Buchanan",
+    url: "https://en.wikipedia.org/wiki/Ian_Buchanan_(academic)",
+    sameAs: [
+      "https://scholars.uow.edu.au/ian-buchanan",
+      "https://www.youtube.com/@ianbuchanan3199"
+    ],
+    jobTitle: "Professor of Cultural Studies",
+  };
+
+  const faqJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faq.map((item) => ({
+      "@type": "Question",
+      name: item.q,
+      acceptedAnswer: { "@type": "Answer", text: item.a },
+    })),
+  };
+
   return (
-    <div className="ib-page">
-      <Breadcrumbs />
+    <>
+      <Helmet>
+        <title>Ian Buchanan – VaultPedia</title>
+        <meta
+          name="description"
+          content="Expanded profile of Ian Buchanan with biography, works, and talks."
+        />
+        <meta
+          name="keywords"
+          content="Ian Buchanan, Deleuze, Guattari, assemblage theory, schizoanalysis"
+        />
+        <meta property="og:title" content="Ian Buchanan – VaultPedia" />
+        <meta
+          property="og:description"
+          content="Expanded profile of Ian Buchanan with biography, works, and talks."
+        />
+        <meta property="og:type" content="profile" />
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content="Ian Buchanan – VaultPedia" />
+        <meta
+          name="twitter:description"
+          content="Expanded profile of Ian Buchanan with biography, works, and talks."
+        />
+        <script type="application/ld+json">
+          {JSON.stringify(personJsonLd)}
+        </script>
+        <script type="application/ld+json">
+          {JSON.stringify(faqJsonLd)}
+        </script>
+      </Helmet>
 
-      <header className="ib-header">
-        <h1>VaultPedia: Ian Buchanan</h1>
-        <p className="ib-subtitle">
-          A curated, expanded “Wikipedia‑style” entry inside the Ian Buchanan Vault: biography, works, reception,
-          conceptual contributions, and selected talks.
-        </p>
-      </header>
+      <div className="ib-page">
+        <Breadcrumbs />
 
-      <div className="ib-layout">
-        <TOC sections={sections} />
+        <header className="ib-header">
+          <h1>VaultPedia: Ian Buchanan</h1>
+          <p className="ib-subtitle">
+            A curated, expanded “Wikipedia‑style” entry inside the Ian Buchanan Vault: biography, works, reception,
+            conceptual contributions, and selected talks.
+          </p>
+          <p className="ib-links">
+            Explore his <a href="/cartography">cartography</a>, <a href="/bibliography">bibliography</a>, and{" "}
+            <a href="/reading-list">reading list</a>.
+          </p>
+        </header>
 
-        <main className="ib-content">
+        <div className="ib-layout">
+          <TOC sections={sections} />
+
+          <main className="ib-content">
           {/* 1. Biography */}
           <section id="biography" className="ib-section">
             <h2>1. Biography</h2>
@@ -250,9 +320,22 @@ export default function IanBuchanan() {
             </div>
           </section>
 
-          {/* 7. References */}
+          {/* 7. FAQ */}
+          <section id="faq" className="ib-section">
+            <h2>7. FAQ</h2>
+            <dl>
+              {faq.map((item) => (
+                <React.Fragment key={item.q}>
+                  <dt>{item.q}</dt>
+                  <dd>{item.a}</dd>
+                </React.Fragment>
+              ))}
+            </dl>
+          </section>
+
+          {/* 8. References */}
           <section id="references" className="ib-section">
-            <h2>7. References</h2>
+            <h2>8. References</h2>
             <div className="ib-actions">
               <button type="button" onClick={() => askKnow(prompts["references"])}>Ask Know about this section</button>
             </div>
@@ -302,6 +385,7 @@ export default function IanBuchanan() {
         </main>
       </div>
     </div>
+    </>
   );
 }
 

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,3 +1,13 @@
 {
-  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }],
+  "headers": [
+    {
+      "source": "/sitemap.xml",
+      "headers": [{ "key": "Cache-Control", "value": "public, max-age=3600" }]
+    },
+    {
+      "source": "/robots.txt",
+      "headers": [{ "key": "Cache-Control", "value": "public, max-age=3600" }]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- wrap app with `HelmetProvider`
- add rich SEO tags and FAQ schema to Ian Buchanan page
- publish `robots.txt` and `sitemap.xml` with caching headers

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b507b94b80832b8de55f421b05ce26