### PR TITLE
feat: add OG image route for Ian Buchanan

### DIFF
--- a/site/api/og/ian-buchanan.jsx
+++ b/site/api/og/ian-buchanan.jsx
@@ -1,0 +1,27 @@
+import { ImageResponse } from "@vercel/og";
+
+export const config = { runtime: "edge" };
+
+export default function handler() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: "#0b0c10",
+          color: "#fff",
+          width: "1200px",
+          height: "630px",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <h1 style={{ fontSize: 72, color: "#fff" }}>Ian Buchanan</h1>
+        <p style={{ fontSize: 36, color: "#d2b356" }}>VaultPedia | Deleuzian Studies</p>
+      </div>
+    ),
+    { width: 1200, height: 630 }
+  );
+}

--- a/site/package.json
+++ b/site/package.json
@@ -19,7 +19,9 @@
     "react-router-dom": "^6.26.0",
     "d3": "^7.9.0",
     "octokit": "^4.0.0",
-    "busboy": "^1.6.0"
+    "busboy": "^1.6.0",
+    "react-helmet": "^6.1.0",
+    "@vercel/og": "^0.8.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/site/src/pages/vaultpedia/IanBuchanan.jsx
+++ b/site/src/pages/vaultpedia/IanBuchanan.jsx
@@ -6,6 +6,7 @@
 // - Drop-in ready for Vite/React. Ensure your router points this path to <IanBuchanan />.
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Helmet } from "react-helmet";
 import "./IanBuchanan.css";
 
 function askKnow(msg) {
@@ -118,6 +119,16 @@ export default function IanBuchanan() {
 
   return (
     <div className="ib-page">
+      <Helmet>
+        <meta
+          property="og:image"
+          content="https://your-app.vercel.app/api/og/ian-buchanan"
+        />
+        <meta
+          name="twitter:image"
+          content="https://your-app.vercel.app/api/og/ian-buchanan"
+        />
+      </Helmet>
       <Breadcrumbs />
 
       <header className="ib-header">

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,3 +1,4 @@
 {
+  "experimental": { "edge": true },
   "rewrites": [{ "source": "/(.*)", "destination": "/" }]
 }


### PR DESCRIPTION
## Summary
- add @vercel/og image generator at `/api/og/ian-buchanan`
- expose OG/Twitter image metadata on VaultPedia Ian Buchanan page
- enable edge runtime in Vercel config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b508027104832b82ad2969524ed4fe