### PR TITLE
CWO-SEO-OG-A03: ensure OG image resolves on cards

### DIFF
--- a/site/api/og/debug.ts
+++ b/site/api/og/debug.ts
@@ -1,0 +1,11 @@
+export const config = { runtime: "edge" };
+export default async function handler(req: Request) {
+  return new Response(
+    JSON.stringify(
+      { ok: true, hint: "Edge runtime active, OG endpoints should work." },
+      null,
+      2
+    ),
+    { headers: { "content-type": "application/json" } }
+  );
+}

--- a/site/api/og/ian-buchanan.tsx
+++ b/site/api/og/ian-buchanan.tsx
@@ -1,25 +1,27 @@
+/* eslint-disable import/no-default-export */
 import { ImageResponse } from "@vercel/og";
 
 export const config = { runtime: "edge" };
 
-export default async function handler(req) {
+export default async function handler(req: Request) {
   const url = new URL(req.url);
   const subtitle =
     url.searchParams.get("s") ||
-    "Deleuze & Guattari studies, assemblage, schizoanalysis";
+    "Deleuze & Guattari studies • assemblage • schizoanalysis";
+
   return new ImageResponse(
     (
       <div
         style={{
-          width: "1200px",
-          height: "630px",
+          width: 1200,
+          height: 630,
           display: "flex",
           flexDirection: "column",
           justifyContent: "space-between",
-          padding: "60px",
+          padding: 60,
           background: "#0b0c10",
           color: "#e6e6e6",
-          fontFamily: "Inter, system-ui, Arial",
+          fontFamily: "Inter, system-ui, Arial, sans-serif",
         }}
       >
         <div style={{ fontSize: 60, fontWeight: 800 }}>Ian Buchanan</div>

--- a/site/src/pages/vaultpedia/IanBuchanan.jsx
+++ b/site/src/pages/vaultpedia/IanBuchanan.jsx
@@ -107,6 +107,11 @@ function ResponsiveYouTube({ id, title }) {
 }
 
 export default function IanBuchanan() {
+  const ORIGIN =
+    (typeof window !== "undefined" && window.location.origin) ||
+    "https://buchanan-vault.vercel.app";
+  const OG_IMAGE = `${ORIGIN}/api/og/ian-buchanan`;
+
   const talks = [
     { id: "S59XUHQHUr0", title: "Ian Buchanan – Assemblage Theory (Machinic Unconscious Happy Hour)" },
     { id: "x7hkNUtIUsk", title: "What were we THINKING??? Affect and Assemblage (ISCIA Seminar)" },
@@ -169,15 +174,16 @@ export default function IanBuchanan() {
           property="og:description"
           content="Deleuze &amp; Guattari studies: assemblage, schizoanalysis, guides and talks."
         />
-        <meta property="og:image" content="/api/og/ian-buchanan" />
+        <meta property="og:image" content={OG_IMAGE} />
         <meta property="og:type" content="article" />
+        <meta property="og:url" content={`${ORIGIN}/vaultpedia/ian-buchanan`} />
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content="Ian Buchanan — VaultPedia" />
         <meta
           name="twitter:description"
           content="Deleuze &amp; Guattari studies: assemblage, schizoanalysis, guides and talks."
         />
-        <meta name="twitter:image" content="/api/og/ian-buchanan" />
+        <meta name="twitter:image" content={OG_IMAGE} />
         <script type="application/ld+json">
           {JSON.stringify(personJsonLd)}
         </script>

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -11,6 +11,8 @@
     }
   ],
   "functions": {
-    "api/og/*.jsx": { "runtime": "edge" }
+    "api/og/*.jsx": { "runtime": "edge" },
+    "api/og/*.ts": { "runtime": "edge" },
+    "api/og/*.tsx": { "runtime": "edge" }
   }
 }


### PR DESCRIPTION
## Summary
- add edge runtime OG image generator under `/api/og/ian-buchanan`
- expose `/api/og/debug` endpoint for quick runtime checks
- generate absolute `og:image` and `twitter:image` URLs on VaultPedia page and update Vercel config

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b511565640832bab64d0b306b48aea