### PR TITLE
fix: remove empty functions block from Vercel config

### DIFF
--- a/site/vercel.json
+++ b/site/vercel.json
@@ -9,8 +9,5 @@
       "source": "/robots.txt",
       "headers": [{ "key": "Cache-Control", "value": "public, max-age=3600" }]
     }
-  ],
-  "functions": {
-    "api/**/*.{js,ts,tsx}": {}
-  }
+  ]
 }


### PR DESCRIPTION
## Summary
- remove empty `functions` block from Vercel config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b516dd1224832b92f66f55d9eb4de6