### PR TITLE
fix: run OG image functions on Edge runtime

### DIFF
--- a/site/api/og/debug.js
+++ b/site/api/og/debug.js
@@ -1,4 +1,4 @@
-export const config = { runtime: 'edge' };
+export const runtime = 'edge';
 export default async function handler() {
   return new Response('ok: edge runtime alive', { status: 200 });
 }

--- a/site/api/og/debug.ts
+++ b/site/api/og/debug.ts
@@ -1,4 +1,4 @@
-export const config = { runtime: "edge" };
+export const runtime = "edge";
 export default async function handler(req: Request) {
   return new Response(
     JSON.stringify(

--- a/site/api/og/ian-buchanan.js
+++ b/site/api/og/ian-buchanan.js
@@ -1,5 +1,4 @@
-// Force edge runtime at the file level (belt & suspenders)
-export const config = { runtime: 'edge' };
+export const runtime = 'edge';
 
 import { ImageResponse } from '@vercel/og';
 

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "rewrites": [{ "source": "/(.*)", "destination": "/" }],
   "headers": [
     {
@@ -9,13 +10,5 @@
       "source": "/robots.txt",
       "headers": [{ "key": "Cache-Control", "value": "public, max-age=3600" }]
     }
-  ],
-  "functions": {
-    "api/og/*.js": {
-      "runtime": "edge"
-    },
-    "api/og/*.ts": {
-      "runtime": "edge"
-    }
-  }
+  ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,3 @@
 {
-  "functions": {
-    "api/og/*.js": { "runtime": "edge" }
-  }
+  "version": 2
 }


### PR DESCRIPTION
## Summary
- declare `edge` runtime inside each `api/og` handler
- remove legacy function mapping from Vercel config

## Testing
- `npm test`
- `npm --prefix site run build` *(fails: Rollup failed to resolve import "react-helmet-async" from site/src/main.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b52e188e20832bb296374543a0d656