### PR TITLE
Resolve OG debug route conflict

### DIFF
--- a/site/api/og/debug.js
+++ b/site/api/og/debug.js
@@ -1,4 +1,0 @@
-export const runtime = 'edge';
-export default async function handler() {
-  return new Response('ok: edge runtime alive', { status: 200 });
-}

--- a/site/api/og/debug.ts
+++ b/site/api/og/debug.ts
@@ -1,11 +1,28 @@
-export const runtime = "edge";
+import { ImageResponse } from '@vercel/og';
+
+export const runtime = 'edge';
+
 export default async function handler(req: Request) {
-  return new Response(
-    JSON.stringify(
-      { ok: true, hint: "Edge runtime active, OG endpoints should work." },
-      null,
-      2
+  const { searchParams } = new URL(req.url);
+  const title = searchParams.get('title') ?? 'OG Debug';
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: 'flex',
+          height: '100%',
+          width: '100%',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#0b0c10',
+          color: '#e6e6e6',
+          fontSize: 60
+        }}
+      >
+        {title}
+      </div>
     ),
-    { headers: { "content-type": "application/json" } }
+    { width: 1200, height: 630 }
   );
 }
+


### PR DESCRIPTION
## Summary
- remove duplicate JavaScript OG debug handler
- implement OG debug handler in TypeScript with Edge runtime and dynamic title

## Testing
- `npm --prefix site test`
- `pytest` *(fails: test_delanda_without_orcid_has_works)*

------
https://chatgpt.com/codex/tasks/task_e_68b5337a9b84832bb32e62edc77508c3